### PR TITLE
Fix aws efa installation

### DIFF
--- a/csp_tools/aws/Dockerfile
+++ b/csp_tools/aws/Dockerfile
@@ -22,9 +22,8 @@ RUN apt-get update && \
     cd /tmp && \
     curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz  && \
     tar -xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz && \
-    cd aws-efa-installer/DEBS/UBUNTU2004/$(uname -m) && \
-    dpkg -i libfabric*.deb && \
-    dpkg -i efa-profile*.deb && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf && \
     ldconfig && \
     rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/* && \
     /opt/amazon/efa/bin/fi_info --version


### PR DESCRIPTION
Hi @maanug-nv, @yaoyu-33, @markelsanz14,

this PR fixes csp_tools/aws/Dockerfile. Without the PR, it would fail as

```
Step 4/11 : RUN apt-get update &&     cd /tmp &&     curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz  &&     tar -xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz &&     cd aws-efa-installer/DEBS/UBUNTU2004/$(uname -m) &&     dpkg -i libfabric*.deb &&     dpkg -i efa-profile*.deb &&     ldconfig &&     rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/* &&     /opt/amazon/efa/bin/fi_info --version
 ---> Running in 2f8c389b9bc9
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]
Get:3 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [2448 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [11.3 MB]
Get:7 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [27.7 kB]
Get:8 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [991 kB]
Get:9 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1882 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [33.4 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [177 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [1275 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [2009 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1291 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2921 kB]
Get:16 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [31.2 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [28.6 kB]
Get:18 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [55.2 kB]
Fetched 25.1 MB in 3s (10.0 MB/s)
Reading package lists...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  302M  100  302M    0     0   289M      0  0:00:01  0:00:01 --:--:--  289M
Selecting previously unselected package libfabric-aws-bin.
(Reading database ... 20933 files and directories currently installed.)
Preparing to unpack libfabric-aws-bin_1.16.1amzn3.0_amd64.deb ...
Unpacking libfabric-aws-bin (1.16.1amzn3.0) ...
Selecting previously unselected package libfabric-aws-dev.
Preparing to unpack libfabric-aws-dev_1.16.1amzn3.0_amd64.deb ...
Unpacking libfabric-aws-dev (1.16.1amzn3.0) ...
Selecting previously unselected package libfabric1-aws.
Preparing to unpack libfabric1-aws_1.16.1amzn3.0_amd64.deb ...
Unpacking libfabric1-aws (1.16.1amzn3.0) ...
dpkg: dependency problems prevent configuration of libfabric1-aws:
 libfabric1-aws depends on ibverbs-providers (>= 43); however:
  Version of ibverbs-providers:amd64 on system is 36.0-1.

dpkg: error processing package libfabric1-aws (--install):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of libfabric-aws-bin:
 libfabric-aws-bin depends on libfabric1-aws; however:
  Package libfabric1-aws is not configured yet.

dpkg: error processing package libfabric-aws-bin (--install):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of libfabric-aws-dev:
 libfabric-aws-dev depends on libfabric1-aws (= 1.16.1amzn3.0); however:
  Package libfabric1-aws is not configured yet.

dpkg: error processing package libfabric-aws-dev (--install):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
Errors were encountered while processing:
 libfabric1-aws
 libfabric-aws-bin
 libfabric-aws-dev
The command '/bin/sh -c apt-get update &&     cd /tmp &&     curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz  &&     tar -xf aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz &&     cd aws-efa-installer/DEBS/UBUNTU2004/$(uname -m) &&     dpkg -i libfabric*.deb &&     dpkg -i efa-profile*.deb &&     ldconfig &&     rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/* &&     /opt/amazon/efa/bin/fi_info --version' returned a non-zero code: 1
```

Please merge. Thank you