### PR TITLE
big auto_configurator changes [seq length, OOMs, new configs]

### DIFF
--- a/auto_configurator/autoconfig/base_config.py
+++ b/auto_configurator/autoconfig/base_config.py
@@ -145,7 +145,7 @@ def _estimate_training_time(
     return None
 
 
-def _calculate_gbs_tp_pp(model_size_in_b: float, gpu_memory_gb: int = 80, model_name: str = "gpt3", seq_length: int) -> Tuple[int]:
+def _calculate_gbs_tp_pp(model_size_in_b: float, seq_length: int, gpu_memory_gb: int = 80, model_name: str = "gpt3") -> Tuple[int]:
     """
     Calculates Global Batch Size (GBS), Tensor Parallelism (TP), and Pipeline
     Parallelism (PP) values, given a model size and model name.
@@ -467,7 +467,7 @@ def generate_base_config(
     """
     # GBS: global batch size
     gbs, tp, pp = _calculate_gbs_tp_pp(
-        model_size_in_b=model_size_in_b, gpu_memory_gb=gpu_memory_gb, model_name=model_name, seq_length=search
+        model_size_in_b=model_size_in_b, gpu_memory_gb=gpu_memory_gb, model_name=model_name, seq_length=seq_length
     )
 
     base_cfg = utils.generic_base_config(cfg, model_name=model_name)

--- a/auto_configurator/autoconfig/base_config.py
+++ b/auto_configurator/autoconfig/base_config.py
@@ -401,6 +401,7 @@ def generate_base_config(
     max_training_days: float,
     num_tokens_in_b: int,
     vocab_size: int,
+    seq_length: int,
     model_name: str,
     cfg: omegaconf.dictconfig.DictConfig,
 ):
@@ -433,7 +434,6 @@ def generate_base_config(
     # TRAINER
     base_cfg["trainer"]["num_nodes"] = nodes
     base_cfg["trainer"]["precision"] = "bf16"
-    seq_length = base_cfg["model"]["data"]["seq_length"]
     base_cfg["trainer"]["max_steps"] = int((num_tokens_in_b * 1e9) / (seq_length * gbs))
     if int_hours == 0:
         int_days -= 1
@@ -459,6 +459,9 @@ def generate_base_config(
         base_cfg["model"]["global_batch_size"] = int(gbs)
         base_cfg["model"]["hidden_size"] = int(hs)
         base_cfg["model"]["num_attention_heads"] = int(att_h)
+        base_cfg["model"]["encoder_seq_length"] = seq_length
+        base_cfg["model"]["max_position_embeddings"] = seq_length
+        base_cfg["model"]["data"]["seq_length"] = seq_length
         if ffn is not None:
             base_cfg["model"]["ffn_hidden_size"] = int(ffn)
         if kv is not None:

--- a/auto_configurator/autoconfig/base_config.py
+++ b/auto_configurator/autoconfig/base_config.py
@@ -466,7 +466,7 @@ def generate_base_config(
     :return: base config object for the given model.
     :rtype: dict
     """
-    base_cfg = utils.generic_base_config(cfg, model_name=model_name)
+    base_cfg = utils.generic_base_config(cfg=cfg, custom_cfg=custom_cfg, model_name=model_name)
 
     # GBS: global batch size
     if custom_cfg is None:

--- a/auto_configurator/autoconfig/scripts/compare_throughput.py
+++ b/auto_configurator/autoconfig/scripts/compare_throughput.py
@@ -25,7 +25,7 @@ def main(cfg):
     result_columns = [
         "Model Name",
         "Model Size",
-        "Seq Length"
+        "Seq Length",
         "TP",
         "PP",
         "MBS",
@@ -47,7 +47,7 @@ def main(cfg):
     error_columns = [
         "Model Name",
         "Model Size",
-        "Seq Length"
+        "Seq Length",
         "TP",
         "PP",
         "MBS",

--- a/auto_configurator/autoconfig/search_config.py
+++ b/auto_configurator/autoconfig/search_config.py
@@ -48,6 +48,7 @@ def search_config(cfg: omegaconf.dictconfig.DictConfig, hydra_args: Optional[str
     vocab_size = train_cfg.get("vocab_size")
     tflops_per_gpu = train_cfg.get("tflops_per_gpu")
     num_tokens_in_b = train_cfg.get("num_tokens_in_b")
+    seq_length = train_cfg.get("seq_length")
 
     gpu_count = nodes * gpus_per_node
     assert isinstance(gpu_count, int) and gpu_count > 0, "nodes * gpus_per_node must be an int larger than zero."
@@ -84,6 +85,7 @@ def search_config(cfg: omegaconf.dictconfig.DictConfig, hydra_args: Optional[str
         max_training_days=max_training_days,
         num_tokens_in_b=num_tokens_in_b,
         vocab_size=vocab_size,
+        seq_length=seq_length,
         cfg=cfg,
         model_name=model_name,
     )

--- a/auto_configurator/autoconfig/search_config.py
+++ b/auto_configurator/autoconfig/search_config.py
@@ -49,6 +49,7 @@ def search_config(cfg: omegaconf.dictconfig.DictConfig, hydra_args: Optional[str
     tflops_per_gpu = train_cfg.get("tflops_per_gpu")
     num_tokens_in_b = train_cfg.get("num_tokens_in_b")
     seq_length = train_cfg.get("seq_length")
+    custom_cfg = train_cfg.get("custom_config")
 
     gpu_count = nodes * gpus_per_node
     assert isinstance(gpu_count, int) and gpu_count > 0, "nodes * gpus_per_node must be an int larger than zero."
@@ -86,6 +87,7 @@ def search_config(cfg: omegaconf.dictconfig.DictConfig, hydra_args: Optional[str
         num_tokens_in_b=num_tokens_in_b,
         vocab_size=vocab_size,
         seq_length=seq_length,
+        custom_cfg=custom_cfg,
         cfg=cfg,
         model_name=model_name,
     )

--- a/auto_configurator/autoconfig/utils.py
+++ b/auto_configurator/autoconfig/utils.py
@@ -303,7 +303,7 @@ def calculate_model_size_params(
     raise Exception("Number of layers not found, config is not possible.")
 
 
-def generic_base_config(cfg: omegaconf.dictconfig.DictConfig, model_name: str = "gpt3") -> dict:
+def generic_base_config(cfg: omegaconf.dictconfig.DictConfig, custom_cfg, model_name: str = "gpt3") -> dict:
     """
     Generates a base config dictionary from a base config yaml file.
     :param omegaconf.dictconfig.DictConfig cfg: hydra-like config object for the HP tool.
@@ -311,7 +311,8 @@ def generic_base_config(cfg: omegaconf.dictconfig.DictConfig, model_name: str = 
     :returns: dictionary containing the base configuration for the model.
     :rtype: dict
     """
-    with open(f"{cfg.auto_configurator_path}/base_configs/{model_name}.yaml") as f:
+    cfg_path = f"{cfg.auto_configurator_path}/base_configs/{model_name}.yaml" if custom_cfg is None else custom_cfg
+    with open(cfg_path) as f:
         base_cfg = yaml.safe_load(f)
     return base_cfg
 

--- a/auto_configurator/autoconfig/utils.py
+++ b/auto_configurator/autoconfig/utils.py
@@ -546,23 +546,6 @@ def add_container_mounts(container_mounts: Optional[List[str]]) -> str:
                 mounts_str += f",{mount}" if ":" in mount else f",{mount}:{mount}"
     return mounts_str
 
-
-def find_error(error_file: str, errors: list = ["CUDA out of memory"]):
-    """
-    Finds the error among job output. 
-    :param list errors: list of "popular" errors. 
-    :param str error_file: path to the job output.
-    :return: str error if job has been failed because of one of listed errors and None if not.
-    :rtype: str
-    """
-    error = None
-    with open(error_file, 'r') as f:
-        output = f.read()
-    for e in errors:
-        if e in output:
-            error = e
-    return error
-
     
 
  

--- a/auto_configurator/autoconfig/utils.py
+++ b/auto_configurator/autoconfig/utils.py
@@ -545,3 +545,24 @@ def add_container_mounts(container_mounts: Optional[List[str]]) -> str:
             if mount is not None and isinstance(mount, str):
                 mounts_str += f",{mount}" if ":" in mount else f",{mount}:{mount}"
     return mounts_str
+
+
+def find_error(error_file: str, errors: list = ["CUDA out of memory"]):
+    """
+    Finds the error among job output. 
+    :param list errors: list of "popular" errors. 
+    :param str error_file: path to the job output.
+    :return: str error if job has been failed because of one of listed errors and None if not.
+    :rtype: str
+    """
+    error = None
+    with open(error_file, 'r') as f:
+        output = f.read()
+    for e in errors:
+        if e in output:
+            error = e
+    return error
+
+    
+
+ 

--- a/auto_configurator/conf/search_config/bert/0.11b.yaml
+++ b/auto_configurator/conf/search_config/bert/0.11b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
   seq_length: 512 # available seq_length list for BERT models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/0.11b.yaml
+++ b/auto_configurator/conf/search_config/bert/0.11b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
+  seq_length: 512 # available seq_length list for BERT models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/100b.yaml
+++ b/auto_configurator/conf/search_config/bert/100b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
   seq_length: 512 # available seq_length list for BERT models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/100b.yaml
+++ b/auto_configurator/conf/search_config/bert/100b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 150  # Estimated tflops per GPU.
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
+  seq_length: 512 # available seq_length list for BERT models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/20b.yaml
+++ b/auto_configurator/conf/search_config/bert/20b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
   seq_length: 512 # available seq_length list for BERT models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/20b.yaml
+++ b/auto_configurator/conf/search_config/bert/20b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
+  seq_length: 512 # available seq_length list for BERT models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/4b.yaml
+++ b/auto_configurator/conf/search_config/bert/4b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
   seq_length: 512 # available seq_length list for BERT models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/4b.yaml
+++ b/auto_configurator/conf/search_config/bert/4b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
+  seq_length: 512 # available seq_length list for BERT models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/bert/unknown_size.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
   seq_length: 512 # available seq_length list for BERT models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/bert/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/bert/unknown_size.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1800  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 30522
+  seq_length: 512 # available seq_length list for BERT models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/0.126b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/0.126b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/0.126b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/0.126b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/0.843b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/0.843b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/0.843b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/0.843b.yaml
@@ -1,0 +1,39 @@
+train_settings:
+  model_size_in_b: 0.843 # unit in billion parameters
+  num_nodes: 8
+  gpus_per_node: 8
+  gpu_memory_gb: 80  # Memory per GPU, in GB. Currently 40GB and 80GB A100s supported.
+  max_training_days: 2 # unit in days
+  limit_search_runs: 100 # Max number of runs to be launched in parallel for grid search.
+  output_top_n: 10  # The result will print the top N fastest training configs.
+  max_steps_per_run: 50 # Max steps per run for the grid search.
+  max_minutes_per_run: 20 # minutes per run for the grid search.
+  tflops_per_gpu: 140  # Estimated tflops per GPU.
+  num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
+  vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
+  tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
+  pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]
+  min_model_parallel_size: auto  # auto to use our recommendation, or a value for the minimum desired parallelism
+  max_model_parallel_size: auto  # auto to use our recommendation, or a value for the maximum desired parallelism
+  micro_batch_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 16]
+  act_ckpt_layers: auto  # auto to use our recommendation, or a list, such as [0, 1, 2, 3]
+ 
+inference_settings:
+  run:
+    model_type: gpt3
+    model_train_name: gpt3_0.843b
+    gpus_per_node: 8
+    data_type: "fp16" # fp32|fp16|bf16
+    time_limit: 0:30:00
+    results_dir: ${base_results_dir}/${search_config_value}_${search_config.train_settings.gpu_memory_gb}gb
+    tensor_parallel_sizes: [1,2]
+    pipeline_parallel_sizes: [1]
+  benchmark:
+    input_len: 60
+    output_len: 20
+    batch_sizes: [4,8,16,32,64,128,256,512]
+    beam_width: 1
+    topk: 4
+    topp: 0.0

--- a/auto_configurator/conf/search_config/gpt3/175b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/175b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/175b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/175b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/20b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/20b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/20b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/20b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/2b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/2b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/2b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/2b.yaml
@@ -1,0 +1,39 @@
+train_settings:
+  model_size_in_b: 2 # unit in billion parameters
+  num_nodes: 8
+  gpus_per_node: 8
+  gpu_memory_gb: 80  # Memory per GPU, in GB. Currently 40GB and 80GB A100s supported.
+  max_training_days: 2 # unit in days
+  limit_search_runs: 100 # Max number of runs to be launched in parallel for grid search.
+  output_top_n: 10  # The result will print the top N fastest training configs.
+  max_steps_per_run: 50 # Max steps per run for the grid search.
+  max_minutes_per_run: 20 # minutes per run for the grid search.
+  tflops_per_gpu: 140  # Estimated tflops per GPU.
+  num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
+  vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
+  tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
+  pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]
+  min_model_parallel_size: auto  # auto to use our recommendation, or a value for the minimum desired parallelism
+  max_model_parallel_size: auto  # auto to use our recommendation, or a value for the maximum desired parallelism
+  micro_batch_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 16]
+  act_ckpt_layers: auto  # auto to use our recommendation, or a list, such as [0, 1, 2, 3]
+ 
+inference_settings:
+  run:
+    model_type: gpt3
+    model_train_name: gpt3_2b
+    gpus_per_node: 8
+    data_type: "fp16" # fp32|fp16|bf16
+    time_limit: 0:30:00
+    results_dir: ${base_results_dir}/${search_config_value}_${search_config.train_settings.gpu_memory_gb}gb
+    tensor_parallel_sizes: [1,2]
+    pipeline_parallel_sizes: [1]
+  benchmark:
+    input_len: 60
+    output_len: 20
+    batch_sizes: [4,8,16,32,64,128,256,512]
+    beam_width: 1
+    topk: 4
+    topp: 0.0

--- a/auto_configurator/conf/search_config/gpt3/40b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/40b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/40b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/40b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/43b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/43b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/43b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/43b.yaml
@@ -1,0 +1,39 @@
+train_settings:
+  model_size_in_b: 43 # unit in billion parameters
+  num_nodes: 128
+  gpus_per_node: 8
+  gpu_memory_gb: 80  # Memory per GPU, in GB. Currently 40GB and 80GB A100s supported.
+  max_training_days: 13 # unit in days
+  limit_search_runs: 100 # Max number of runs to be launched in parallel for grid search.
+  output_top_n: 10  # The result will print the top N fastest training configs.
+  max_steps_per_run: 50 # Max steps per run for the grid search.
+  max_minutes_per_run: 20 # minutes per run for the grid search.
+  tflops_per_gpu: 140  # Estimated tflops per GPU.
+  num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
+  vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
+  tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
+  pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]
+  min_model_parallel_size: auto  # auto to use our recommendation, or a value for the minimum desired parallelism
+  max_model_parallel_size: auto  # auto to use our recommendation, or a value for the maximum desired parallelism
+  micro_batch_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 16]
+  act_ckpt_layers: auto  # auto to use our recommendation, or a list, such as [0, 1, 2, 3]
+ 
+inference_settings:
+  run:
+    model_type: gpt3
+    model_train_name: gpt3_43b
+    gpus_per_node: 8
+    data_type: "fp16" # fp32|fp16|bf16
+    time_limit: 0:30:00
+    results_dir: ${base_results_dir}/${search_config_value}_${search_config.train_settings.gpu_memory_gb}gb
+    tensor_parallel_sizes: [4,8,16]
+    pipeline_parallel_sizes: [1,2,4,8]
+  benchmark:
+    input_len: 60
+    output_len: 20
+    batch_sizes: [4,8,16,32,64,128,256]
+    beam_width: 1
+    topk: 4
+    topp: 0.0

--- a/auto_configurator/conf/search_config/gpt3/5b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/5b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/5b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/5b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/8b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/8b.yaml
@@ -1,0 +1,39 @@
+train_settings:
+  model_size_in_b: 8 # unit in billion parameters
+  num_nodes: 16
+  gpus_per_node: 8
+  gpu_memory_gb: 80  # Memory per GPU, in GB. Currently 40GB and 80GB A100s supported.
+  max_training_days: 5 # unit in days
+  limit_search_runs: 100 # Max number of runs to be launched in parallel for grid search.
+  output_top_n: 10  # The result will print the top N fastest training configs.
+  max_steps_per_run: 50 # Max steps per run for the grid search.
+  max_minutes_per_run: 10 # minutes per run for the grid search.
+  tflops_per_gpu: 140  # Estimated tflops per GPU.
+  num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
+  vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
+  tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
+  pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]
+  min_model_parallel_size: auto  # auto to use our recommendation, or a value for the minimum desired parallelism
+  max_model_parallel_size: auto  # auto to use our recommendation, or a value for the maximum desired parallelism
+  micro_batch_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 16]
+  act_ckpt_layers: auto  # auto to use our recommendation, or a list, such as [0, 1, 2, 3]
+ 
+inference_settings:
+  run:
+    model_type: gpt3
+    model_train_name: gpt3_8b
+    gpus_per_node: 8
+    data_type: "fp16" # fp32|fp16|bf16
+    time_limit: 0:30:00
+    results_dir: ${base_results_dir}/${search_config_value}_${search_config.train_settings.gpu_memory_gb}gb
+    tensor_parallel_sizes: [1,2,4]
+    pipeline_parallel_sizes: [1,2]
+  benchmark:
+    input_len: 60
+    output_len: 20
+    batch_sizes: [4,8,16,32,64,128,256]
+    beam_width: 1
+    topk: 4
+    topp: 0.0

--- a/auto_configurator/conf/search_config/gpt3/8b.yaml
+++ b/auto_configurator/conf/search_config/gpt3/8b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/gpt3/unknown_size.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
+  seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/gpt3/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/gpt3/unknown_size.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 300  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 51200
   seq_length: 2048 # available seq_length list for GPT-3 models: [2048, 4096, 8192]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/gpt3/126m
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/0.17b.yaml
+++ b/auto_configurator/conf/search_config/mt5/0.17b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/0.17b.yaml
+++ b/auto_configurator/conf/search_config/mt5/0.17b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/0.39b.yaml
+++ b/auto_configurator/conf/search_config/mt5/0.39b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/0.39b.yaml
+++ b/auto_configurator/conf/search_config/mt5/0.39b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/101.6b.yaml
+++ b/auto_configurator/conf/search_config/mt5/101.6b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/101.6b.yaml
+++ b/auto_configurator/conf/search_config/mt5/101.6b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/11.9b.yaml
+++ b/auto_configurator/conf/search_config/mt5/11.9b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/11.9b.yaml
+++ b/auto_configurator/conf/search_config/mt5/11.9b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/206b.yaml
+++ b/auto_configurator/conf/search_config/mt5/206b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/206b.yaml
+++ b/auto_configurator/conf/search_config/mt5/206b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/24.65b.yaml
+++ b/auto_configurator/conf/search_config/mt5/24.65b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/24.65b.yaml
+++ b/auto_configurator/conf/search_config/mt5/24.65b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/3.2b.yaml
+++ b/auto_configurator/conf/search_config/mt5/3.2b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/3.2b.yaml
+++ b/auto_configurator/conf/search_config/mt5/3.2b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/42.54b.yaml
+++ b/auto_configurator/conf/search_config/mt5/42.54b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/42.54b.yaml
+++ b/auto_configurator/conf/search_config/mt5/42.54b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/mt5/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/mt5/unknown_size.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
+  seq_length: 512 # available seq_length list for MT5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   override_search_num_nodes: auto  # auto to use the minimum required number of nodes
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]

--- a/auto_configurator/conf/search_config/mt5/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/mt5/unknown_size.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 250000
   seq_length: 512 # available seq_length list for MT5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/mt5/0.17b
   override_search_num_nodes: auto  # auto to use the minimum required number of nodes
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]

--- a/auto_configurator/conf/search_config/t5/0.22b.yaml
+++ b/auto_configurator/conf/search_config/t5/0.22b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/0.22b.yaml
+++ b/auto_configurator/conf/search_config/t5/0.22b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/100b.yaml
+++ b/auto_configurator/conf/search_config/t5/100b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/100b.yaml
+++ b/auto_configurator/conf/search_config/t5/100b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/11b.yaml
+++ b/auto_configurator/conf/search_config/t5/11b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/11b.yaml
+++ b/auto_configurator/conf/search_config/t5/11b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/2.8b.yaml
+++ b/auto_configurator/conf/search_config/t5/2.8b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/2.8b.yaml
+++ b/auto_configurator/conf/search_config/t5/2.8b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/203b.yaml
+++ b/auto_configurator/conf/search_config/t5/203b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/203b.yaml
+++ b/auto_configurator/conf/search_config/t5/203b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/23.5b.yaml
+++ b/auto_configurator/conf/search_config/t5/23.5b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/23.5b.yaml
+++ b/auto_configurator/conf/search_config/t5/23.5b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/41.2b.yaml
+++ b/auto_configurator/conf/search_config/t5/41.2b.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/41.2b.yaml
+++ b/auto_configurator/conf/search_config/t5/41.2b.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]
   pipeline_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8, 10]

--- a/auto_configurator/conf/search_config/t5/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/t5/unknown_size.yaml
@@ -12,6 +12,7 @@ train_settings:
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
   seq_length: 512 # available seq_length list for T5 models: [512]
+  custom_config: null # path to custom .yaml model config instead of using auto-generated
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   override_search_num_nodes: auto  # auto to use the minimum required number of nodes
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]

--- a/auto_configurator/conf/search_config/t5/unknown_size.yaml
+++ b/auto_configurator/conf/search_config/t5/unknown_size.yaml
@@ -11,6 +11,7 @@ train_settings:
   tflops_per_gpu: 140  # Estimated tflops per GPU.
   num_tokens_in_b: 1000  # Unit in billions, typically 300B for GPT3 models.
   vocab_size: 29000
+  seq_length: 512 # available seq_length list for T5 models: [512]
   logs: ${base_results_dir}/${search_config_value}_${.gpu_memory_gb}gb  # Example base_results_dir/t5/0.22b
   override_search_num_nodes: auto  # auto to use the minimum required number of nodes
   tensor_parallel_sizes: auto  # auto to use our recommendation, or a list, such as [1, 2, 4, 8]


### PR DESCRIPTION
**PR changes:**

1. Added seq_length value to configs (mutable from config from now). Longer sequence length (4K and 8K) available only for GPT models (up to 45B size) for now.

3. Changed heuristics (gbs / mbs / tp / pp generation) in respect to different seq length.
4. Added a feature which looks for OOM errors among failed jobs and saves .csv with configs that failed with OOM so we don't have to search for OOMs manually. Easy to add search for other popular errors in future.
5. Added custom_config value to configs. We are able to use own custom model config from now if needed (instead of fully-generated by auto_configurator).
6. New GPT models configs were added (for 843M, 2B, 8B, 43B models).