### PR TITLE
Fix the incorrect path for the nemo-data-curator within the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ Command Manager.
 
 
 ```
-srun -p [partition] -N 1 --container-mounts=/path/to/local/dir:/workspace/mount_dir --container-image=[container_tag] bash -c "cp -r /opt/NeMo-Megatron-Launcher/launcher_scripts /opt/NeMo-Megatron-Launcher/auto_configurator /opt/FasterTransformer /opt/NeMo-Data-Curator /workspace/mount_dir/"
+srun -p [partition] -N 1 --container-mounts=/path/to/local/dir:/workspace/mount_dir --container-image=[container_tag] bash -c "cp -r /opt/NeMo-Megatron-Launcher/launcher_scripts /opt/NeMo-Megatron-Launcher/auto_configurator /opt/FasterTransformer /opt/nemo-data-curator /workspace/mount_dir/"
 ```
 
 Install the NeMo Framework scripts dependencies on the head node of the cluster:


### PR DESCRIPTION
This fixes the incorrect path to the `nemo-data-curator` for the container copy command (provided in section 5.1.1.1) that was introduced in #33 .