### PR TITLE
Add nemo model support for gpt eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,8 @@ numa_mapping:
   max_cores: 8  # Maximum number of physical cores per process. Can be null to use all available cores.
 ```
 
+**Interactive**: In order to run the launcher in an interactive job or locally on a workstation, 
+set `cluster_type=interactive` in `conf/config.yaml`.
 
 **Slurm**: The `launcher_scripts_path` parameter will automatically be mounted to the
 container at the same path as in the local file system. Any additional

--- a/README.md
+++ b/README.md
@@ -3677,7 +3677,7 @@ Any other parameter can also be added to the command to modify its behavior.
 <a id="markdown-interleaved-pipeline-parallelism" name="interleaved-pipeline-parallelism"></a>
 If your model was trained with interleaved pipeline parallelism, then the model must converted to a non-interleaved model.
 In order to check if your model used interleaved, inspect the training config and verify that
-`model.virtual_pipeline_model_parallel_size>0`.
+`model.virtual_pipeline_model_parallel_size > 0`.
 
 To convert the model, use the script from the NeMo Toolkit: [examples/nlp/language_modeling/megatron_change_num_partitions.py](https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/megatron_change_num_partitions.py)
 

--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -42,7 +42,7 @@ env_vars:
   NCCL_IB_TIMEOUT: null # InfiniBand Verbs Timeout. Set to 22 for Azure
   NCCL_DEBUG: null # Logging level for NCCL. Set to "INFO" for debug information
   NCCL_PROTO: null # Protocol NCCL will use. Set to "simple" for AWS
-  TRANSFORMER_OFFLINE: 1
+  TRANSFORMERS_OFFLINE: 1
   NCCL_AVOID_RECORD_STREAMS: 1
 
 # GPU Mapping

--- a/launcher_scripts/conf/evaluation/gpt3/evaluate_all.yaml
+++ b/launcher_scripts/conf/evaluation/gpt3/evaluate_all.yaml
@@ -12,6 +12,7 @@ run:
 
 model:
   model_type: nemo-gpt3
+  nemo_model: null # run eval with a .nemo file, produced when converted interleaved checkpoints
   checkpoint_folder: ${evaluation.run.train_dir}/results/checkpoints
   checkpoint_name: latest # latest OR name pattern of a checkpoint (e.g. megatron_gpt-*last.ckpt)
   hparams_file: ${evaluation.run.train_dir}/results/hparams.yaml

--- a/launcher_scripts/conf/evaluation/gpt3/evaluate_lambada.yaml
+++ b/launcher_scripts/conf/evaluation/gpt3/evaluate_lambada.yaml
@@ -12,6 +12,7 @@ run:
 
 model:
   model_type: nemo-gpt3
+  nemo_model: null # run eval with a .nemo file, produced when converted interleaved checkpoints
   checkpoint_folder: ${evaluation.run.train_dir}/results/checkpoints
   checkpoint_name: latest # latest OR name pattern of a checkpoint (e.g. megatron_gpt-*last.ckpt)
   hparams_file: ${evaluation.run.train_dir}/results/hparams.yaml

--- a/launcher_scripts/nemo_launcher/collections/eval_harness/lm_eval/models/nemo_gpt3.py
+++ b/launcher_scripts/nemo_launcher/collections/eval_harness/lm_eval/models/nemo_gpt3.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 import os
+from omegaconf import OmegaConf, open_dict
 
 import torch
 import tqdm
-from apex.transformer import parallel_state
+from megatron.core import parallel_state
 from lm_eval import utils
 from lm_eval.base import LM
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
 from nemo.collections.nlp.modules.common.megatron.megatron_init import fake_initialize_model_parallel
 from nemo.collections.nlp.modules.common.text_generation_utils import generate, get_computeprob_response
-from nemo.collections.nlp.parts.nlp_overrides import NLPDDPStrategy
-from nemo.core.connectors.save_restore_connector import SaveRestoreConnector
+from nemo.collections.nlp.parts.nlp_overrides import NLPDDPStrategy, NLPSaveRestoreConnector
 from nemo.utils import logging
 from nemo.utils.app_state import AppState
 from nemo.utils.get_rank import is_global_rank_zero
@@ -93,13 +93,32 @@ def setup_trainer_and_model(args):
         )
 
     if args.nemo_model is not None:
-        logging.info(f"**** Loading checkpoint from {args.nemo_model}")
-        connector = SaveRestoreConnector()
+        logging.info(f"**** Loading checkpoint from nemo model: {args.nemo_model}")
+        save_restore_connector = NLPSaveRestoreConnector()
         if os.path.isdir(args.nemo_model):
-            connector._model_extracted_dir = args.nemo_model
-        model = MegatronGPTModel.restore_from(
-            restore_path=args.nemo_model, save_restore_connector=connector, trainer=trainer
+            save_restore_connector._model_extracted_dir = args.nemo_model
+        pretrained_cfg = MegatronGPTModel.restore_from(
+            restore_path=args.nemo_model,
+            trainer=trainer,
+            return_config=True,
+            save_restore_connector=save_restore_connector,
         )
+        OmegaConf.set_struct(pretrained_cfg, True)
+        with open_dict(pretrained_cfg):
+            pretrained_cfg.sequence_parallel = False
+            pretrained_cfg.activations_checkpoint_granularity = None
+            pretrained_cfg.activations_checkpoint_method = None
+            pretrained_cfg.precision = trainer.precision
+            if trainer.precision == "16":
+                pretrained_cfg.megatron_amp_O2 = False
+        model = MegatronGPTModel.restore_from(
+            restore_path=args.nemo_model,
+            trainer=trainer,
+            override_config_path=pretrained_cfg,
+            save_restore_connector=save_restore_connector,
+            map_location=f'cuda:{trainer.local_rank}',
+        )
+
     else:
         if args.tensor_model_parallel_size > 1 or args.pipeline_model_parallel_size > 1:
             app_state.pipeline_model_parallel_size = args.pipeline_model_parallel_size

--- a/launcher_scripts/nemo_launcher/collections/eval_harness/lm_eval/models/nemo_gpt3.py
+++ b/launcher_scripts/nemo_launcher/collections/eval_harness/lm_eval/models/nemo_gpt3.py
@@ -92,7 +92,7 @@ def setup_trainer_and_model(args):
             pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
         )
 
-    if args.nemo_model is not None:
+    if args.nemo_model is not None and args.nemo_model != "None":
         logging.info(f"**** Loading checkpoint from nemo model: {args.nemo_model}")
         save_restore_connector = NLPSaveRestoreConnector()
         if os.path.isdir(args.nemo_model):

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -911,10 +911,12 @@ class EvalHarnessEvaluation(NemoMegatronStage):
                 prompt_dataset_paths=model_cfg.get("prompt_dataset_paths"),
             )
         else:
+            # GPT evaluation
             args += create_args_list(
                 replace_underscore=False,
                 vocab_file=model_cfg.get("vocab_file"),
                 merge_file=model_cfg.get("merge_file"),
+                nemo_model=model_cfg.get("nemo_model"),
                 checkpoint_folder=model_cfg.get("checkpoint_folder"),
                 checkpoint_name=model_cfg.get("checkpoint_name"),
                 hparams_file=model_cfg.get("hparams_file"),


### PR DESCRIPTION
When training GPT with interleaved pipeline parallelism, the model bust be converted to a non-interleaved model. The conversion script creates a .nemo file so the GPT eval suite must be updated to use a .nemo file.