### PR TITLE
ramp up nodes support for ramp up bs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2375,9 +2375,9 @@ in `conf/training/gpt3/5b.yaml`. The parameters can be modified to adjust the
 hyperparameters of the training runs. All supported model types and sizes can be found
 in `conf/training` folder.
 
-We support changeable global batch size during training. It can be set by changing `rampup_batch_size` parameter under the training config. Should be a list of 3 values: `[<start_batch_size>, <batch_size_increment>, <rampup_samples>]`:
-`rampup_batch_size=[256, 128, 50000000]`
-In case of using ramp up batch size nodes shceduler will be created which allows use smaller number of nodes for smaller batch size stages. Nodes scheduler will be automatically according to `training.trainer.num_nodes` parameter.
+We support changeable global batch size during training. It can be set by changing `rampup_batch_size` parameter under the training config. Should be a list of 3 values: `[<start_batch_size>, <batch_size_increment>, <rampup_samples>]`<br>.
+Example: `rampup_batch_size=[256, 128, 50000000]`<br>.
+In case of using ramp up batch size, nodes shceduler will be created. It allows use smaller number of nodes for smaller batch size stages. Nodes scheduler will be automatically according to `training.trainer.num_nodes` parameter.
 
 ##### 5.6.1.1. Slurm
 <a id="markdown-slurm" name="slurm"></a>

--- a/README.md
+++ b/README.md
@@ -2375,6 +2375,10 @@ in `conf/training/gpt3/5b.yaml`. The parameters can be modified to adjust the
 hyperparameters of the training runs. All supported model types and sizes can be found
 in `conf/training` folder.
 
+We support changeable global batch size during training. It can be set by changing `rampup_batch_size` parameter under the training config. Should be a list of 3 values: `[<start_batch_size>, <batch_size_increment>, <rampup_samples>]`:
+`rampup_batch_size=[256, 128, 50000000]`
+In case of using ramp up batch size nodes shceduler will be created which allows use smaller number of nodes for smaller batch size stages. Nodes scheduler will be automatically according to `training.trainer.num_nodes` parameter.
+
 ##### 5.6.1.1. Slurm
 <a id="markdown-slurm" name="slurm"></a>
 

--- a/launcher_scripts/conf/training/gpt3/126m.yaml
+++ b/launcher_scripts/conf/training/gpt3/126m.yaml
@@ -50,6 +50,7 @@ exp_manager:
 model:
   micro_batch_size: 4
   global_batch_size: 256
+  rampup_batch_size: [32, 32, 10000]
   tensor_model_parallel_size: 1
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null # interleaved pipeline

--- a/launcher_scripts/conf/training/gpt3/126m.yaml
+++ b/launcher_scripts/conf/training/gpt3/126m.yaml
@@ -50,7 +50,7 @@ exp_manager:
 model:
   micro_batch_size: 4
   global_batch_size: 256
-  rampup_batch_size: [32, 32, 10000]
+  rampup_batch_size: null
   tensor_model_parallel_size: 1
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null # interleaved pipeline

--- a/launcher_scripts/conf/training/gpt3/175b.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 1
   global_batch_size: 2048
+  rampup_batch_size: null
   tensor_model_parallel_size: 8
   pipeline_model_parallel_size: 16
   virtual_pipeline_model_parallel_size: 6 # interleaved pipeline

--- a/launcher_scripts/conf/training/gpt3/1b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/1b_improved.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 2
   global_batch_size: 512
+  rampup_batch_size: null
   tensor_model_parallel_size: 1
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null

--- a/launcher_scripts/conf/training/gpt3/20b.yaml
+++ b/launcher_scripts/conf/training/gpt3/20b.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 2
   global_batch_size: 2048
+  rampup_batch_size: null
   tensor_model_parallel_size: 4
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null # interleaved pipeline

--- a/launcher_scripts/conf/training/gpt3/400m_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/400m_improved.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 4
   global_batch_size: 256
+  rampup_batch_size: null
   tensor_model_parallel_size: 1
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null

--- a/launcher_scripts/conf/training/gpt3/40b.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 2
   global_batch_size: 2048
+  rampup_batch_size: null
   tensor_model_parallel_size: 8
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null # interleaved pipeline

--- a/launcher_scripts/conf/training/gpt3/40b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b_improved.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 2
   global_batch_size: 1536
+  rampup_batch_size: null
   tensor_model_parallel_size: 8
   pipeline_model_parallel_size: 2
   virtual_pipeline_model_parallel_size: null

--- a/launcher_scripts/conf/training/gpt3/5b.yaml
+++ b/launcher_scripts/conf/training/gpt3/5b.yaml
@@ -50,6 +50,7 @@ model:
   # model parallelism: MBS=2, TPS=2, AGB=8 for 80GB nodes. 
   micro_batch_size: 2
   global_batch_size: 2048
+  rampup_batch_size: null
   tensor_model_parallel_size: 1
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null # interleaved pipeline

--- a/launcher_scripts/conf/training/gpt3/7b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/7b_improved.yaml
@@ -49,6 +49,7 @@ exp_manager:
 model:
   micro_batch_size: 2
   global_batch_size: 512
+  rampup_batch_size: null
   tensor_model_parallel_size: 2
   pipeline_model_parallel_size: 1
   virtual_pipeline_model_parallel_size: null

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -14,7 +14,9 @@
 
 import copy
 import functools
-import os
+import glob, os
+import json
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -43,6 +45,8 @@ class NemoMegatronStage:
         self.setup_stage_vars(cfg)
         self.job_name = self.stage_cfg.run.get("name")
 
+        self.nodes_scheduler = {}
+
     def setup_stage_vars(self, cfg: OmegaConf):
         """Setup the stage vars, i.e. stage name and stage cfg"""
         raise NotImplementedError
@@ -58,6 +62,15 @@ class NemoMegatronStage:
         self.setup_folder_and_data()
         # Save stage hydra config
         job_path = self.get_job_path()
+
+        gpus = self.stage_cfg.get("trainer").get("devices")
+        if self.cfg.get('training').get('model').get('rampup_batch_size'):
+            self._find_optimal_nodes(self.cfg, gpus)
+            current_gbs = self._get_current_gbs(self.cfg)
+            nodes = self.nodes_scheduler[str(current_gbs)]
+            self.stage_cfg["trainer"]["num_nodes"] = nodes
+            self.cfg['training']["trainer"]["num_nodes"] = nodes
+
         stage_cfg_path = NemoMegatronStage.save_stage_hydra_config(self.stage_cfg, job_path)
         # Make cluster parameters
         cluster_parameters = self._make_cluster_parameters(self.cluster)
@@ -218,7 +231,6 @@ class NemoMegatronStage:
         """
         cfg = self.cfg
         stage_cfg = self.stage_cfg
-
         run_cfg = stage_cfg.get("run")
         job_name = run_cfg.get("name")
         time_limit = run_cfg.get("time_limit")
@@ -226,6 +238,7 @@ class NemoMegatronStage:
         dependency = run_cfg.get("dependency")
         if nodes is None:
             nodes = stage_cfg.get("trainer").get("num_nodes")
+        
         ntasks_per_node = run_cfg.get("ntasks_per_node")
         if ntasks_per_node is None:
             ntasks_per_node = stage_cfg.get("trainer").get("devices")
@@ -268,6 +281,63 @@ class NemoMegatronStage:
             cluster_parameters.update(shared_parameters)
 
         return cluster_parameters
+    
+    def _find_optimal_nodes(self, cfg, gpus) -> None:
+        nodes_scheduler_path = f"{cfg.get('training').get('run').get('results_dir')}/nodes_scheduler.json"
+
+        try:
+            with open(nodes_scheduler_path, 'r') as nodes_scheduler:
+                self.nodes_scheduler = json.load(nodes_scheduler)
+        except FileNotFoundError:
+            mbs = cfg.get('training').get('model').get('micro_batch_size')
+            gbs = cfg.get('training').get('model').get('global_batch_size')
+            rampup_bs = cfg.get('training').get('model').get('rampup_batch_size')
+            tp = cfg.get('training').get('model').get('tensor_model_parallel_size')
+            pp = cfg.get('training').get('model').get('pipeline_model_parallel_size')
+            num_nodes = cfg.get('training').get('trainer').get('num_nodes')
+            increment = rampup_bs[1]
+
+            bs = 0
+            rbs = []
+            while bs <= (gbs - increment):
+                rbs.append(bs + increment)
+                bs += increment
+
+            self.nodes_scheduler[gbs] = num_nodes
+            for b in rbs[::-1]:
+                optimal_lst = []
+                prev = min(list(self.nodes_scheduler.values()))
+                for nodes in range(1, prev + 1):
+                    dp = (gpus * nodes) // (tp * pp)
+                    if b % (mbs * dp) == 0 and b % (mbs * gpus * nodes) == 0 and nodes <= prev:
+                        optimal_lst.append(nodes)
+        
+                self.nodes_scheduler[str(b)] = max(optimal_lst)
+            
+            with open(nodes_scheduler_path, 'w') as nodes_scheduler:
+                nodes_scheduler.write(json.dumps(self.nodes_scheduler))
+    
+    def _get_current_gbs(self, cfg):
+        start_bs = cfg.get('training').get('model').get('rampup_batch_size')[0]
+        results_dir = cfg.get('training').get('run').get('results_dir')
+        os.chdir(results_dir)
+        job_numbers = []
+
+        try:
+            for file in glob.glob("*.out"):
+                file = file.split('_')[-1].split('.')[0]
+                job_numbers.append(int(file))
+        
+            job_number = max(job_numbers)
+            last_job = glob.glob(f"*{job_number}.out")[0]
+            with open(last_job, 'r') as logs:
+                logs = logs.read()
+        
+            current_gbs = re.findall(r'global_batch_size=(\d+)', logs)[-1]
+        except:
+            current_gbs =  start_bs
+    
+        return current_gbs
 
     def get_env_vars(self) -> Dict:
         """


### PR DESCRIPTION
PR changes:
1. Added ramp up bs param to configs.
2. Created a function which finds optimal number of nodes for each ramp up bs stage.
3. Created a function which finds current global batch size through the logs files between different training runs (in order to start next job with correct number of nodes which is related to current global batch size).
4. Added related documentaion to readme.