### PR TITLE
bug fix

### DIFF
--- a/launcher_scripts/nemo_launcher/collections/eval_harness/lm_eval/models/nemo_gpt3.py
+++ b/launcher_scripts/nemo_launcher/collections/eval_harness/lm_eval/models/nemo_gpt3.py
@@ -290,6 +290,7 @@ class NeMo_GPT3LM_TP_PP(LM):
                 top_k=0,
                 top_p=0.9,
                 greedy=True,
+                compute_logprob=True,
                 repetition_penalty=1.0,
                 min_tokens_to_generate=0,
             )


### PR DESCRIPTION
not setting `compute_logprob=True` will cause `full_logits` [here](https://github.com/blahBlahhhJ/NeMo/blob/main/nemo/collections/nlp/modules/common/text_generation_utils.py#L430) to be `None`. And broadcasting it will error.
This issue will happen when evaluating GPT models on Lambada task.