### PR TITLE
Add support for training GPT models on Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsndfile1 \
         sox \
         swig \
+        openssh-server \
         libb64-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -178,6 +179,12 @@ RUN pip install --no-cache-dir wandb==0.15.3 \
 
 # Copy FasterTransformer
 COPY --from=ft_builder /workspace/FasterTransformer FasterTransformer
+
+# Setup SSH config to allow mpi-operator to communicate with containers in k8s
+RUN echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    sed -i 's/#   StrictHostKeyChecking ask/    StrictHostKeyChecking no/' /etc/ssh/ssh_config && \
+    mkdir -p /var/run/sshd
 
 # Examples
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
     + [4.1.1. Common](#411-common)
     + [4.1.2. OCI](#412-oci)
     + [4.1.3. AWS](#413-aws)
-    + [4.1.4. Kubernetes](#414-k8s)
   * [4.2. Cluster Validation](#42-cluster-validation)
     + [4.2.1. Validation Script Usage](#421-validation-script-usage)
     + [4.2.2 Running tests manually](#422-running-tests-manually)
@@ -33,14 +32,12 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
     + [5.1.1. Prepare Environment](#511-prepare-environment)
       - [5.1.1.1. Slurm](#5111-slurm)
       - [5.1.1.2. Base Command Platform](#5112-base-command-platform)
-      - [5.1.1.3. Kubernetes](#5113-kubernetes)
-      - [5.1.1.4. General Configuration](#5114-general-configuration)
+      - [5.1.1.3. General Configuration](#5113-general-configuration)
     + [5.1.2. Data Preparation](#512-data-preparation)
       - [5.1.2.1. Data Preparation for GPT Models](#5121-data-preparation-for-gpt-models)
         * [5.1.2.1.1. Slurm](#51211-slurm)
         * [5.1.2.1.2. Base Command Platform](#51212-base-command-platform)
-        * [5.1.2.1.3. Kubernetes](#51213-kubernetes)
-        * [5.1.2.1.4. Common](#51214-common)
+        * [5.1.2.1.3. Common](#51213-common)
       - [5.1.2.2. Data Preparation for T5 Models](#5122-data-preparation-for-t5-models)
         * [5.1.2.2.1. Slurm](#51221-slurm)
         * [5.1.2.2.2. Base Command Platform](#51222-base-command-platform)
@@ -88,7 +85,6 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
     + [5.6.1. GPT Training](#561-gpt-training)
       - [5.6.1.1. Slurm](#5611-slurm)
       - [5.6.1.2. Base Command Platform](#5612-base-command-platform)
-      - [5.6.1.3. Kubernetes](#5613-base-command-platform)
     + [5.6.2. T5 Training](#562-t5-training)
       - [5.6.2.1. Slurm](#5621-slurm)
       - [5.6.2.2. Base Command Platform](#5622-base-command-platform)
@@ -104,7 +100,6 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
       - [5.8.1.1. Common](#5811-common)
       - [5.8.1.2. Slurm](#5812-slurm)
       - [5.8.1.3. Base Command Platform](#5813-base-command-platform)
-      - [5.8.1.4. Kubernetes](#5814-kubernetes)
     + [5.8.2. T5 Conversion](#582-t5-conversion)
       - [5.8.2.1. Common](#5821-common)
       - [5.8.2.2. Slurm](#5822-slurm)
@@ -157,8 +152,7 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
       - [5.13.1.1. Common](#51311-common)
       - [5.13.1.2. Slurm](#51312-slurm)
       - [5.13.1.3. Base Command Platform](#51313-base-command-platform)
-      - [5.13.1.4. Kubernetes](#51314-kubernetes)
-      - [5.13.1.5 Interleaved Pipeline Parallelism](#51314-interleaved-pipeline-parallelism)
+      - [5.13.1.4 Interleaved Pipeline Parallelism](#51314-interleaved-pipeline-parallelism)
     + [5.13.2. T5 Evaluation](#5132-t5-evaluation)
       - [5.13.2.1. Common](#51321-common)
       - [5.13.2.2. Slurm](#51322-slurm)
@@ -377,11 +371,6 @@ Figure 1: The GPT family architecture. The 5B variant includes 24 transformer la
 | HPC-X                   | 2.13             |
 | Base Command Manager    | 1.0.0            |
 | DeepOps                 | 21.06            |
-| Kubernetes              | 1.27.4           |
-| Helm                    | 3.12.1           |
-| GPU Operator            | 23.3.2           |
-| Network Operator        | 23.1.0           |
-| KubeFlow Operator       | 1.6.0            |
 
 ## 4. Cloud Service Providers
 <a id="markdown-cloud-service-providers" name="cloud-service-providers"></a>
@@ -430,23 +419,6 @@ On the scheduler node:
 - Set the container path in `launcher_scripts/conf/config.yaml` to the new Enroot image:
 ```
 container: /path/to/nemo_megatron_launcher/nemo_megatron_training.sqsh
-```
-
-#### 4.1.4. Kubernetes
-<a id="markdown-k8s" name="k8s"></a>
-Data preparation and training GPT models is currently supported on vanilla kubernetes (k8s) clusters.
-The launcher scripts will generate a Helm chart for each task based on the config files and launch the job using the chart.
-
-The following is required for running jobs on Kubernetes:
-  * One or more DGX A100s/H100s as worker nodes
-  * An NFS filesystem where the data and launcher scripts will be stored which is accessible on all worker and controller nodes
-  * A head/controller node which has access to the worker nodes and can run `kubectl` and `helm` to launch jobs and can install Python dependencies
-  * Recent versions of the GPU, Network, and KubeFlow Operators installed
-
-A secret key needs to be configured to allow kubernetes to pull from the private registry. For example, if pulling the container directly
-from NGC, a secret needs to be created to authenticate with the private NGC registry, such as the following:
-```
-kubectl create secret docker-registry ngc-registry --docker-server=nvcr.io --docker-username=\$oauthtoken --docker-password=<NGC KEY HERE>
 ```
 
 ### 4.2. Cluster Validation
@@ -632,22 +604,7 @@ creating these workspaces (e.g. `nemo_megatron_data_ws` and `nemo_megatron_resul
 the Base Command Platform User Guide for how to create and work with Base 
 Command Platform workspaces.
 
-##### 5.1.1.3. Kubernetes
-<a id="markdown-kubernetes" name="kubernetes"></a>
-
-The launcher scripts need to be downloaded to the NFS filesystem that is
-connected to the worker nodes. This can either be copied at
-`/opt/NeMo-Megatron-Launcher` from inside the training container or by cloning
-this repository.
-
-Install the NeMo Framework scripts dependencies on the head node/controller of
-the cluster where jobs will be launched:
-
-```
-pip install -r requirements.txt
-```
-
-##### 5.1.1.4. General Configuration
+##### 5.1.1.3. General Configuration
 <a id="markdown-general-configuration" name="general-configuration"></a>
 
 The first parameter that must be set is the `launcher_scripts_path` parameter inside the
@@ -895,36 +852,8 @@ The command above assumes you want to prepare the entire dataset (files 0-29), a
 workspace in `/mount/data`, and the results workspace in `/mount/results`. Stdout and stderr are redirected to the `/results/data_gpt3_log.txt` file, so it can be downloaded from NGC. 
 Any other parameter can also be added to the command to modify its behavior.
 
-###### 5.1.2.1.3. Kubernetes
-<a id="markdown-51213-kubernetes" name="51213-kubernetes"></a>
-
-To run data preparation on a kubernetes cluster, set both the `cluster` and
-`cluster_type` parameters to `k8s` in `conf/config.yaml`. Additionally, set the
-`launcher_scripts_path` parameter to the location where the launcher scripts
-are located on the NFS filesystem. This must be the same path on all nodes in
-the cluster. Ensure the `stages` parameter is set to `data_preparation` and
-`data_preparation` in the `defaults` section points to the intended data
-preparation script.
-
-The `conf/config/k8s.yaml` file also needs to be updated with the
-kubernetes container registry secret if created earlier (`pull_secret`), the
-`shm_size` to determine how much local memory to put in each pod, and the NFS
-server and path to where the launcher scripts are saved. These can all be
-overridden from the command line using hydra as well.
-
-Once all of the config files are updated, the data preparation can be launched
-from the controller node with:
-
-```
-python main.py
-```
-
-This will generate and launch a job via Helm in the default namespace which
-can be viewed with `helm show` or `kubectl get pods`. The logs can be followed
-with `kubectl logs <pod-name>`.
-
-###### 5.1.2.1.4. Common
-<a id="markdown-51214-common" name="51214-common"></a>
+###### 5.1.2.1.3. Common
+<a id="markdown-41213-common" name="41213-common"></a>
 
 Set the configuration for the data preparation job for GPT models in the YAML file:
 ```yaml
@@ -2533,89 +2462,6 @@ Select the cluster related configuration following the NGC documentation.
 Then, use the `python3 main.py` command to launch the job and override the 
 desired parameters from the training job parameters.
 
-##### 5.6.1.3. Kubernetes
-<a id="markdown-kuberetes" name="kubernetes"></a>
-
-Set configuration for your Kubernetes cluster in the `conf/cluster/k8s.yaml` file:
-
-```yaml
-pull_secret: null
-shm_size: 512Gi
-nfs_server: null
-nfs_path: null
-ib_resource_name: "nvidia.com/hostdev"
-ib_count: "8"
-```
-
-The settings are as follows:
-  * `pull_secret`: The name of the sercret key created with `kubectl` that will
-  be used to authenticate with private registries for pulling the training
-  container.
-  * `shm_size`: The amount of shared memory to include in the Pods. It is
-  recommended to use a large value here.
-  * `nfs_server`: The IP address or hostname of the NFS server that the worker
-  nodes will read and write data to/from.
-  * `nfs_path`: The absolute path on the NFS server that should be mounted
-  inside the Pods.
-  * `ib_resource_name`: The name of the IB interconnect to attach to Pods for
-  multi-node training. This is the name that Kubernetes assigns to the NICs as
-  allocatable resources.
-  * `ib_count`: The number of IB interconnects to include per node in each pod.
-  This will likely equal the total number of active/usable compute NICs per
-  node.
-
-And set the training job specific parameters in the `conf/training/(model_type)/(model_size).yaml` file, 
-using the run section:
-```yaml
-run:
-    name: gpt3_126m
-    results_dir: ${base_results_dir}/${.name}
-    time_limit: "1-12:00:00"
-    dependency: "singleton"
-```
-
-To run only the training pipeline and not the data preparation, evaluation or
-inference pipelines, set the `conf/config.yaml` file to:
-
-```yaml
-stages:
-  - training
-```
-
-Also set the `cluster` and `cluster_type` values to `k8s` in the
-`conf/config.yaml` file.
-
-And then run:
-```
-python3 main.py
-```
-
-Once the launcher is run, it will display the path to the Helm chart that was
-generated based on the updated config files. The Helm chart will be located in
-the job results directory by default. The chart will be run automatically and
-Pods will be started by Kubernetes once resources become available. The status
-of the Helm chart can be checked with:
-
-```
-$ helm list
-NAME           	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                        	APP VERSION
-gpt-7b-improved	default  	1       	2023-07-17 14:10:11.794541205 -0700 PDT	deployed	nemo-framework-training-1.0.0	1.0
-```
-
-Once allocated, this will spin up N pods for N number of nodes requested. To
-view training progress follow the log of the first pod, typically named
-`nlp-training-worker-0`.
-
-Once a job is finished, it will be marked as complete via Helm and can be
-uninstalled with (note - replace `<job-name>` with the name of the Helm chart
-as shown in the previous example):
-
-```
-$ helm uninstall <job-name>
-```
-
-The uninstallation will not affect the completed job - it will only mark the
-resources as free for Kubernetes to use them for future tasks.
 
 #### 5.6.2. T5 Training
 <a id="markdown-t5-training" name="t5-training"></a>
@@ -2902,22 +2748,6 @@ conversion.model.checkpoint_folder=/mount/results/gpt3_126m/results/checkpoints 
 The command above assumes you mounted the data workspace in `/mount/data`, and the results workspace in `/mount/results`. 
 The stdout and stderr outputs will also be redirected to the `/results/convert_gpt3_log.txt` file, to be able to download the logs from NGC.
 Any other parameter can also be added to the command to modify its behavior.
-
-##### 5.8.1.4. Kubernetes
-<a id="markdown-kubernetes" name="kubernetes"></a>
-To convert a model to the `.nemo` format on a Kubernetes cluster, set both the
-`cluster` and `cluster_type` parameters to `k8s` in `conf/config.yaml`. Update
-the `conf/conversion/gpt3/convert_gpt3.yaml` config file to point to the model
-you would like to convert.
-
-Once the configs are ready, run:
-
-```
-python3 main.py
-```
-
-This will launch a Helm chart that will spawn a job that runs on one of the
-compute nodes to convert the requested model to the `.nemo` format.
 
 #### 5.8.2. T5 Conversion
 <a id="markdown-t5-conversion" name="t5-conversion"></a>
@@ -4098,22 +3928,7 @@ The command above assumes you mounted the data workspace in `/mount/data`, and t
 The stdout and stderr outputs will also be redirected to the `/results/eval_gpt3_log.txt` file, to be able to download the logs from NGC.
 Any other parameter can also be added to the command to modify its behavior.
 
-##### 5.13.1.4. Kubernetes
-<a id="markdown-kubernetes" name="kubernetes"></a>
-To evaluate base models on Kubernetes clusters, set the `cluster` and
-`cluster_type` parameters to `k8s` in `conf/config.yaml`. Update either the
-`conf/evaluation/gpt3/evaluate_all.yaml` or `conf/evaluation/gpt3/evaluate_lambada.yaml`
-file based on your cluster and desired evaluation tasks. Once the configurations
-are updated, launch an evaluation job with:
-
-```
-python3 main.py
-```
-
-This will launch a Helm chart based on the evaluation configurations which will
-download all task files and run evaluation against the specified model.
-
-##### 5.13.1.5 Interleaved Pipeline Parallelism
+##### 5.13.1.4 Interleaved Pipeline Parallelism
 <a id="markdown-interleaved-pipeline-parallelism" name="interleaved-pipeline-parallelism"></a>
 If your model was trained with interleaved pipeline parallelism, then the model must converted to a non-interleaved model.
 In order to check if your model used interleaved, inspect the training config and verify that

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
     + [4.1.1. Common](#411-common)
     + [4.1.2. OCI](#412-oci)
     + [4.1.3. AWS](#413-aws)
+    + [4.1.4. Kubernetes](#414-k8s)
   * [4.2. Cluster Validation](#42-cluster-validation)
     + [4.2.1. Validation Script Usage](#421-validation-script-usage)
     + [4.2.2 Running tests manually](#422-running-tests-manually)
@@ -32,12 +33,14 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
     + [5.1.1. Prepare Environment](#511-prepare-environment)
       - [5.1.1.1. Slurm](#5111-slurm)
       - [5.1.1.2. Base Command Platform](#5112-base-command-platform)
-      - [5.1.1.3. General Configuration](#5113-general-configuration)
+      - [5.1.1.3. Kubernetes](#5113-kubernetes)
+      - [5.1.1.4. General Configuration](#5114-general-configuration)
     + [5.1.2. Data Preparation](#512-data-preparation)
       - [5.1.2.1. Data Preparation for GPT Models](#5121-data-preparation-for-gpt-models)
         * [5.1.2.1.1. Slurm](#51211-slurm)
         * [5.1.2.1.2. Base Command Platform](#51212-base-command-platform)
-        * [5.1.2.1.3. Common](#51213-common)
+        * [5.1.2.1.3. Kubernetes](#51213-kubernetes)
+        * [5.1.2.1.4. Common](#51214-common)
       - [5.1.2.2. Data Preparation for T5 Models](#5122-data-preparation-for-t5-models)
         * [5.1.2.2.1. Slurm](#51221-slurm)
         * [5.1.2.2.2. Base Command Platform](#51222-base-command-platform)
@@ -85,6 +88,7 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
     + [5.6.1. GPT Training](#561-gpt-training)
       - [5.6.1.1. Slurm](#5611-slurm)
       - [5.6.1.2. Base Command Platform](#5612-base-command-platform)
+      - [5.6.1.3. Kubernetes](#5613-base-command-platform)
     + [5.6.2. T5 Training](#562-t5-training)
       - [5.6.2.1. Slurm](#5621-slurm)
       - [5.6.2.2. Base Command Platform](#5622-base-command-platform)
@@ -100,6 +104,7 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
       - [5.8.1.1. Common](#5811-common)
       - [5.8.1.2. Slurm](#5812-slurm)
       - [5.8.1.3. Base Command Platform](#5813-base-command-platform)
+      - [5.8.1.4. Kubernetes](#5814-kubernetes)
     + [5.8.2. T5 Conversion](#582-t5-conversion)
       - [5.8.2.1. Common](#5821-common)
       - [5.8.2.2. Slurm](#5822-slurm)
@@ -152,7 +157,8 @@ The most recent version of the README can be found at [https://ngc.nvidia.com/co
       - [5.13.1.1. Common](#51311-common)
       - [5.13.1.2. Slurm](#51312-slurm)
       - [5.13.1.3. Base Command Platform](#51313-base-command-platform)
-      - [5.13.1.4 Interleaved Pipeline Parallelism](#51314-interleaved-pipeline-parallelism)
+      - [5.13.1.4. Kubernetes](#51314-kubernetes)
+      - [5.13.1.5 Interleaved Pipeline Parallelism](#51314-interleaved-pipeline-parallelism)
     + [5.13.2. T5 Evaluation](#5132-t5-evaluation)
       - [5.13.2.1. Common](#51321-common)
       - [5.13.2.2. Slurm](#51322-slurm)
@@ -371,6 +377,11 @@ Figure 1: The GPT family architecture. The 5B variant includes 24 transformer la
 | HPC-X                   | 2.13             |
 | Base Command Manager    | 1.0.0            |
 | DeepOps                 | 21.06            |
+| Kubernetes              | 1.27.4           |
+| Helm                    | 3.12.1           |
+| GPU Operator            | 23.3.2           |
+| Network Operator        | 23.1.0           |
+| KubeFlow Operator       | 1.6.0            |
 
 ## 4. Cloud Service Providers
 <a id="markdown-cloud-service-providers" name="cloud-service-providers"></a>
@@ -419,6 +430,23 @@ On the scheduler node:
 - Set the container path in `launcher_scripts/conf/config.yaml` to the new Enroot image:
 ```
 container: /path/to/nemo_megatron_launcher/nemo_megatron_training.sqsh
+```
+
+#### 4.1.4. Kubernetes
+<a id="markdown-k8s" name="k8s"></a>
+Data preparation and training GPT models is currently supported on vanilla kubernetes (k8s) clusters.
+The launcher scripts will generate a Helm chart for each task based on the config files and launch the job using the chart.
+
+The following is required for running jobs on Kubernetes:
+  * One or more DGX A100s/H100s as worker nodes
+  * An NFS filesystem where the data and launcher scripts will be stored which is accessible on all worker and controller nodes
+  * A head/controller node which has access to the worker nodes and can run `kubectl` and `helm` to launch jobs and can install Python dependencies
+  * Recent versions of the GPU, Network, and KubeFlow Operators installed
+
+A secret key needs to be configured to allow kubernetes to pull from the private registry. For example, if pulling the container directly
+from NGC, a secret needs to be created to authenticate with the private NGC registry, such as the following:
+```
+kubectl create secret docker-registry ngc-registry --docker-server=nvcr.io --docker-username=\$oauthtoken --docker-password=<NGC KEY HERE>
 ```
 
 ### 4.2. Cluster Validation
@@ -604,7 +632,22 @@ creating these workspaces (e.g. `nemo_megatron_data_ws` and `nemo_megatron_resul
 the Base Command Platform User Guide for how to create and work with Base 
 Command Platform workspaces.
 
-##### 5.1.1.3. General Configuration
+##### 5.1.1.3. Kubernetes
+<a id="markdown-kubernetes" name="kubernetes"></a>
+
+The launcher scripts need to be downloaded to the NFS filesystem that is
+connected to the worker nodes. This can either be copied at
+`/opt/NeMo-Megatron-Launcher` from inside the training container or by cloning
+this repository.
+
+Install the NeMo Framework scripts dependencies on the head node/controller of
+the cluster where jobs will be launched:
+
+```
+pip install -r requirements.txt
+```
+
+##### 5.1.1.4. General Configuration
 <a id="markdown-general-configuration" name="general-configuration"></a>
 
 The first parameter that must be set is the `launcher_scripts_path` parameter inside the
@@ -852,8 +895,36 @@ The command above assumes you want to prepare the entire dataset (files 0-29), a
 workspace in `/mount/data`, and the results workspace in `/mount/results`. Stdout and stderr are redirected to the `/results/data_gpt3_log.txt` file, so it can be downloaded from NGC. 
 Any other parameter can also be added to the command to modify its behavior.
 
-###### 5.1.2.1.3. Common
-<a id="markdown-41213-common" name="41213-common"></a>
+###### 5.1.2.1.3. Kubernetes
+<a id="markdown-51213-kubernetes" name="51213-kubernetes"></a>
+
+To run data preparation on a kubernetes cluster, set both the `cluster` and
+`cluster_type` parameters to `k8s` in `conf/config.yaml`. Additionally, set the
+`launcher_scripts_path` parameter to the location where the launcher scripts
+are located on the NFS filesystem. This must be the same path on all nodes in
+the cluster. Ensure the `stages` parameter is set to `data_preparation` and
+`data_preparation` in the `defaults` section points to the intended data
+preparation script.
+
+The `conf/config/k8s.yaml` file also needs to be updated with the
+kubernetes container registry secret if created earlier (`pull_secret`), the
+`shm_size` to determine how much local memory to put in each pod, and the NFS
+server and path to where the launcher scripts are saved. These can all be
+overridden from the command line using hydra as well.
+
+Once all of the config files are updated, the data preparation can be launched
+from the controller node with:
+
+```
+python main.py
+```
+
+This will generate and launch a job via Helm in the default namespace which
+can be viewed with `helm show` or `kubectl get pods`. The logs can be followed
+with `kubectl logs <pod-name>`.
+
+###### 5.1.2.1.4. Common
+<a id="markdown-51214-common" name="51214-common"></a>
 
 Set the configuration for the data preparation job for GPT models in the YAML file:
 ```yaml
@@ -2462,6 +2533,89 @@ Select the cluster related configuration following the NGC documentation.
 Then, use the `python3 main.py` command to launch the job and override the 
 desired parameters from the training job parameters.
 
+##### 5.6.1.3. Kubernetes
+<a id="markdown-kuberetes" name="kubernetes"></a>
+
+Set configuration for your Kubernetes cluster in the `conf/cluster/k8s.yaml` file:
+
+```yaml
+pull_secret: null
+shm_size: 512Gi
+nfs_server: null
+nfs_path: null
+ib_resource_name: "nvidia.com/hostdev"
+ib_count: "8"
+```
+
+The settings are as follows:
+  * `pull_secret`: The name of the sercret key created with `kubectl` that will
+  be used to authenticate with private registries for pulling the training
+  container.
+  * `shm_size`: The amount of shared memory to include in the Pods. It is
+  recommended to use a large value here.
+  * `nfs_server`: The IP address or hostname of the NFS server that the worker
+  nodes will read and write data to/from.
+  * `nfs_path`: The absolute path on the NFS server that should be mounted
+  inside the Pods.
+  * `ib_resource_name`: The name of the IB interconnect to attach to Pods for
+  multi-node training. This is the name that Kubernetes assigns to the NICs as
+  allocatable resources.
+  * `ib_count`: The number of IB interconnects to include per node in each pod.
+  This will likely equal the total number of active/usable compute NICs per
+  node.
+
+And set the training job specific parameters in the `conf/training/(model_type)/(model_size).yaml` file, 
+using the run section:
+```yaml
+run:
+    name: gpt3_126m
+    results_dir: ${base_results_dir}/${.name}
+    time_limit: "1-12:00:00"
+    dependency: "singleton"
+```
+
+To run only the training pipeline and not the data preparation, evaluation or
+inference pipelines, set the `conf/config.yaml` file to:
+
+```yaml
+stages:
+  - training
+```
+
+Also set the `cluster` and `cluster_type` values to `k8s` in the
+`conf/config.yaml` file.
+
+And then run:
+```
+python3 main.py
+```
+
+Once the launcher is run, it will display the path to the Helm chart that was
+generated based on the updated config files. The Helm chart will be located in
+the job results directory by default. The chart will be run automatically and
+Pods will be started by Kubernetes once resources become available. The status
+of the Helm chart can be checked with:
+
+```
+$ helm list
+NAME           	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                        	APP VERSION
+gpt-7b-improved	default  	1       	2023-07-17 14:10:11.794541205 -0700 PDT	deployed	nemo-framework-training-1.0.0	1.0
+```
+
+Once allocated, this will spin up N pods for N number of nodes requested. To
+view training progress follow the log of the first pod, typically named
+`nlp-training-worker-0`.
+
+Once a job is finished, it will be marked as complete via Helm and can be
+uninstalled with (note - replace `<job-name>` with the name of the Helm chart
+as shown in the previous example):
+
+```
+$ helm uninstall <job-name>
+```
+
+The uninstallation will not affect the completed job - it will only mark the
+resources as free for Kubernetes to use them for future tasks.
 
 #### 5.6.2. T5 Training
 <a id="markdown-t5-training" name="t5-training"></a>
@@ -2748,6 +2902,22 @@ conversion.model.checkpoint_folder=/mount/results/gpt3_126m/results/checkpoints 
 The command above assumes you mounted the data workspace in `/mount/data`, and the results workspace in `/mount/results`. 
 The stdout and stderr outputs will also be redirected to the `/results/convert_gpt3_log.txt` file, to be able to download the logs from NGC.
 Any other parameter can also be added to the command to modify its behavior.
+
+##### 5.8.1.4. Kubernetes
+<a id="markdown-kubernetes" name="kubernetes"></a>
+To convert a model to the `.nemo` format on a Kubernetes cluster, set both the
+`cluster` and `cluster_type` parameters to `k8s` in `conf/config.yaml`. Update
+the `conf/conversion/gpt3/convert_gpt3.yaml` config file to point to the model
+you would like to convert.
+
+Once the configs are ready, run:
+
+```
+python3 main.py
+```
+
+This will launch a Helm chart that will spawn a job that runs on one of the
+compute nodes to convert the requested model to the `.nemo` format.
 
 #### 5.8.2. T5 Conversion
 <a id="markdown-t5-conversion" name="t5-conversion"></a>
@@ -3928,7 +4098,22 @@ The command above assumes you mounted the data workspace in `/mount/data`, and t
 The stdout and stderr outputs will also be redirected to the `/results/eval_gpt3_log.txt` file, to be able to download the logs from NGC.
 Any other parameter can also be added to the command to modify its behavior.
 
-##### 5.13.1.4 Interleaved Pipeline Parallelism
+##### 5.13.1.4. Kubernetes
+<a id="markdown-kubernetes" name="kubernetes"></a>
+To evaluate base models on Kubernetes clusters, set the `cluster` and
+`cluster_type` parameters to `k8s` in `conf/config.yaml`. Update either the
+`conf/evaluation/gpt3/evaluate_all.yaml` or `conf/evaluation/gpt3/evaluate_lambada.yaml`
+file based on your cluster and desired evaluation tasks. Once the configurations
+are updated, launch an evaluation job with:
+
+```
+python3 main.py
+```
+
+This will launch a Helm chart based on the evaluation configurations which will
+download all task files and run evaluation against the specified model.
+
+##### 5.13.1.5 Interleaved Pipeline Parallelism
 <a id="markdown-interleaved-pipeline-parallelism" name="interleaved-pipeline-parallelism"></a>
 If your model was trained with interleaved pipeline parallelism, then the model must converted to a non-interleaved model.
 In order to check if your model used interleaved, inspect the training config and verify that

--- a/launcher_scripts/conf/cluster/k8s.yaml
+++ b/launcher_scripts/conf/cluster/k8s.yaml
@@ -1,0 +1,6 @@
+pull_secret: null  # Kubernetes secret for the container registry to pull private containers.
+shm_size: 512Gi  # Amount of system memory to allocate in Pods. Should end in "Gi" for gigabytes.
+nfs_server: null  # Hostname or IP address for the NFS server where data is stored.
+nfs_path: null  # Path to store data in the NFS server.
+ib_resource_name: "nvidia.com/hostdev"  # Specify the resource name for IB devices according to kubernetes, such as "nvidia.com/hostdev" for Mellanox IB adapters.
+ib_count: "8"  # Specify the number of IB devices to include per node in each pod.

--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -1,6 +1,6 @@
 defaults:
   - _self_
-  - cluster: bcm  # Leave it as bcm even if using bcp. It will be ignored for bcp.
+  - cluster: bcm  # Set to bcm for BCM and BCP clusters. Set to k8s for a k8s cluster.
   - data_preparation: gpt3/download_gpt3_pile
   - training: gpt3/5b
   - conversion: gpt3/convert_gpt3
@@ -25,7 +25,7 @@ stages:
   - evaluation
   - export
 
-cluster_type: bcm  # bcm or bcp. If bcm, it must match - cluster above.
+cluster_type: bcm  # bcm, bcp, or k8s. If bcm or k8s, it must match - cluster above.
 launcher_scripts_path: ???  # Path to NeMo Megatron Launch scripts, should ends with /launcher_scripts
 data_dir: ${launcher_scripts_path}/data  # Location to store and read the data.
 base_results_dir: ${launcher_scripts_path}/results  # Location to store the results, checkpoints and logs.

--- a/launcher_scripts/conf/data_preparation/gpt3/download_gpt3_pile.yaml
+++ b/launcher_scripts/conf/data_preparation/gpt3/download_gpt3_pile.yaml
@@ -9,7 +9,7 @@ run:
 
 dataset: pile
 download_the_pile: True  # Whether to download the pile dataset from the internet.
-the_pile_url: "https://mystic.the-eye.eu/public/AI/pile/train/"  # Source URL to download The Pile dataset from.
+the_pile_url: "https://the-eye.eu/public/AI/pile/train/"  # Source URL to download The Pile dataset from.
 file_numbers: "0-29"  # The pile dataset consists of 30 files (0-29), choose which ones to download.
 preprocess_data: True  # True to preprocess the data from a jsonl file, False otherwise.
 download_vocab_url: "https://huggingface.co/gpt2/resolve/main/vocab.json"  # URL to download the vocab from.

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/download.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/download.py
@@ -35,7 +35,7 @@ def main(cfg):
         url = f"{pile_url_train}{file_number:02d}.jsonl.zst"
         output_file = f"{file_number:02d}.jsonl.zst"
         downloaded_path = utils.download_single_file(url, data_dir, output_file)
-    if cfg.get("cluster_type") == "bcp":
+    if cfg.get("cluster_type") in ["bcp", "k8s"]:
         file_numbers = cfg["file_numbers"]
         # Downloading the files
         files_list = utils.convert_file_numbers(file_numbers)

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/extract.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/extract.py
@@ -35,7 +35,7 @@ def main(cfg) -> None:
         downloaded_path = os.path.join(data_dir, f"{file_number:02d}.jsonl.zst")
         output_file = f"{file_number:02d}.jsonl"
         utils.extract_single_zst_file(downloaded_path, data_dir, output_file, rm_downloaded)
-    elif cfg.get("cluster_type") == "bcp":
+    elif cfg.get("cluster_type") in ["bcp", "k8s"]:
         file_numbers = cfg.get("file_numbers")
         # Downloading the files
         files_list = utils.convert_file_numbers(file_numbers)

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
@@ -91,7 +91,7 @@ def main(cfg):
         os.system(runcmd)
         if rm_extracted:
             os.remove(extracted_path)
-    elif cfg.get("cluster_type") == "bcp":
+    elif cfg.get("cluster_type") in ["bcp", "k8s"]:
         file_numbers = cfg.get("file_numbers")
         files_list = utils.convert_file_numbers(file_numbers)
         # Assumes launched via mpirun:

--- a/launcher_scripts/nemo_launcher/core/export_stages.py
+++ b/launcher_scripts/nemo_launcher/core/export_stages.py
@@ -108,7 +108,7 @@ class Export(NemoMegatronStage):
             job_path = self.get_job_path(sub_stage)
             job_path.folder.mkdir(parents=True, exist_ok=True)
 
-            stage_cfg_path = NemoMegatronStage.save_stage_hydra_config(self.stage_cfg, job_path)
+            stage_cfg_path = NemoMegatronStage.save_stage_hydra_config(self.stage_cfg, job_path, self.cfg)
             if job_id:
                 dependency = f"aftercorr:{job_id}"
                 self.stage_cfg["run"]["dependency"] = dependency

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/conversion/Chart.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/conversion/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: NeMo Framework Base Model Conversion
+name: nemo-framework-conversion
+version: 1.0.0

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/conversion/conversion.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/conversion/conversion.yaml
@@ -1,0 +1,48 @@
+{{ $config := .Values.trainingConfig }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nlp-conversion
+  labels:
+    app: nlp-conversion
+spec:
+  template:
+    spec:
+      containers:
+      - name: nlp-conversion
+        image: {{ .Values.image.trainingImage }}
+        env:
+          - name: NCCL_AVOID_RECORD_STREAMS
+            value: "1"
+        command: ["/bin/bash", "-c"]
+        args:
+          - 'export CKPT_NAME=$(python3 {{ $config.launcherScriptsPath }}/nemo_launcher/collections/checkpoint_search.py checkpoint_folder={{ $config.trainingDirectory }}/results/checkpoints checkpoint_name=latest tensor_model_parallel_size=1 pipeline_model_parallel_size=1) &&
+          echo ${CKPT_NAME} &&
+          python3 {{ $config.launcherScriptsPath }}/nemo_launcher/collections/hparams_override.py hparams_file={{ $config.trainingDirectory }}/results/hparams.yaml output_path={{ $config.resultsDirectory }}/results vocab_file={{ $config.vocabPath }} merge_file={{ $config.mergesPath }} tokenizer_model=None &&
+          python3 /opt/NeMo/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py --gpus_per_node=1 --model_type=gpt --checkpoint_folder={{ $config.trainingDirectory }}/results/checkpoints --checkpoint_name=${CKPT_NAME} --hparams_file={{ $config.resultsDirectory }}/results/hparams_override.yaml --nemo_file_path={{ $config.resultsDirectory }}/megatron_gpt.nemo --tensor_model_parallel_size={{ $config.tensorParallelism }} --pipeline_model_parallel_size={{ $config.pipelineParallelism }}'
+        imagePullPolicy: Always
+        resources:
+          requests:
+            nvidia.com/gpu: {{ .Values.image.gpuNum }}
+          limits:
+            nvidia.com/gpu: {{ .Values.image.gpuNum }}
+        volumeMounts:
+        - mountPath: {{ $config.NFSPath }}
+          name: workspace
+        - mountPath: /dev/shm
+          name: dshm
+      restartPolicy: Never
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+
+      volumes:
+      - name: workspace
+        nfs:
+          server: {{ $config.NFSServer }}
+          path: {{ $config.NFSPath }}
+
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ $config.shmSize }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/conversion/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/conversion/values.yaml
@@ -1,0 +1,40 @@
+image:
+  trainingImage: cfg.container
+  pullPolicy: IfNotPresent
+
+  # Insert the name of your container registry pull secret #
+  pullSecret: nvcr.io
+
+  # Insert number of GPUs #
+  gpuNum: <Insert number of GPUs>
+
+trainingConfig:
+  # Specify the amount of shared memory to attach to the Pods #
+  shmSize: 512Gi
+
+  # Insert the address for the NFS server if using NFS for model storage #
+  NFSServer: <Insert NFS server address>
+
+  # Insert the path to save data on the NFS server #
+  NFSPath: <Insert NFS server path>
+
+  # Insert the path to the vocab file #
+  vocabPath: <Insert absolute path to vocab.json file>
+
+  # Insert the path to the merges file #
+  mergesPath: <Insert absolute path to merges.txt file>
+
+  # Insert the path to the results directory #
+  resultsDirectory: <Insert absolute path to the conversion directory>
+
+  # Insert the path to the training directory #
+  trainingDirectory: <Insert the absolute path to the training directory>
+
+  # Insert the path to the launcher_scripts directory #
+  launcherScriptsPath: <Insert the absolute path to the launcher_scripts directory>
+
+  # Insert the TP size #
+  tensorParallelism: <Insert TP size>
+
+  # Insert the PP size #
+  pipelineParallelism: <Insert PP size>

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/Chart.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: NeMo Framework Data Preparation
+name: nemo-framework-data-prep
+version: 1.0.0

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/data-prep-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/data-prep-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-prep-config
+data:
+  config.yaml: |-
+  {{ (.Files.Glob "config/*hydra.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/data-prep.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/data-prep.yaml
@@ -1,0 +1,59 @@
+{{ $config := .Values.dataPrepConfig }}
+
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: nlp-data-prep
+  labels:
+    app: nlp-data-prep
+spec:
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: nlp-data-prep
+            image: {{ .Values.image.trainingImage }}
+            command: ["bash", "-c"]
+            args:
+              - '{{- range tuple "download" "extract" "preprocess" }} mpirun --allow-run-as-root -np {{ $config.totalProcesses }} -npernode {{ $config.procsPerNode }} -bind-to none -map-by slot --oversubscribe -x PYTHONPATH -mca pml ob1 -mca btl ^openib python3 /opt/NeMo-Megatron-Launcher/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/{{ . }}.py --config-path=/config --config-name=config.yaml && {{- end}} echo Data preparation complete'
+            imagePullPolicy: Always
+          imagePullSecrets:
+          - name: {{ .Values.image.pullSecret }}
+    Worker:
+      replicas: {{ .Values.image.nodes }}
+      template:
+        spec:
+          containers:
+          - name: nlp-data-prep
+            image: {{ .Values.image.trainingImage }}
+            command: ["/usr/sbin/sshd"]
+            args:
+              - "-De"
+            volumeMounts:
+            - mountPath: {{ $config.NFSPath }}
+              name: workspace
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /config
+              name: data-prep-config
+            imagePullPolicy: Always
+          restartPolicy: Never
+          imagePullSecrets:
+          - name: {{ .Values.image.pullSecret }}
+
+          volumes:
+          - name: workspace
+            nfs:
+              server: {{ $config.NFSServer }}
+              path: {{ $config.NFSPath }}
+
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: {{ $config.shmSize }}
+
+          - configMap:
+              name: data-prep-config
+            name: data-prep-config

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/data_preparation/values.yaml
@@ -1,0 +1,27 @@
+image:
+  trainingImage: cfg.container
+  pullPolicy: IfNotPresent
+
+  # Insert the name of your container registry pull secret #
+  pullSecret: nvcr.io
+
+  nodes: training.trainer.num_nodes
+
+dataPrepConfig:
+  # Specify the amount of shared memory to attach to the Pods #
+  shmSize: 512Gi
+
+  # Insert the address for the NFS server if using NFS for model storage #
+  NFSServer: <Insert NFS server address>
+
+  # Insert the path to save data on the NFS server #
+  NFSPath: <Insert NFS server path>
+
+  # Insert the total number of processes to spawn on the cluster #
+  totalProcesses: <Insert number of processes>
+
+  # Insert the number of processes to spawn per node #
+  procsPerNode: <Insert number of processes per node>
+
+  # Insert the data preparation stage, such as download, extract, or preprocess #
+  stage: <Insert the data prep stage>

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/Chart.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: NeMo Framework Evaluation
+name: nemo-framework-evaluation
+version: 1.0.0

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/evaluation-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/evaluation-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evaluation-config
+data:
+  hparams.yaml: |-
+  {{ (.Files.Glob "config/hparams.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/evaluation.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/evaluation.yaml
@@ -1,0 +1,53 @@
+{{ $config := .Values.trainingConfig }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nlp-evaluation
+  labels:
+    app: nlp-evaluation
+spec:
+  template:
+    spec:
+      containers:
+      - name: nlp-evaluation
+        image: {{ .Values.image.trainingImage }}
+        env:
+          - name: NCCL_AVOID_RECORD_STREAMS
+            value: "1"
+        command: ["/bin/bash", "-c"]
+        args:
+          - 'python3 {{ $config.launcherScriptsPath }}/nemo_launcher/collections/eval_harness/download.py --tasks=all_tasks --cache-dir={{ $config.cacheDir }} &&
+          mkdir -p {{ $config.outputPath }} &&
+          python3 {{ $config.launcherScriptsPath }}/nemo_launcher/collections/eval_harness/evaluate.py --name={{ $config.name }} --model={{ $config.model }} --tasks={{ $config.tasks }} --cache_dir={{ $config.cacheDir }} --output_path={{ $config.outputPath }} --batch_size={{ $config.batchSize }} --tensor_model_parallel_size={{ $config.tensorParallelism }} --pipeline_model_parallel_size={{ $config.pipelineParallelism }} --precision={{ $config.precision }} --vocab_file={{ $config.vocabPath }} --merge_file={{ $config.mergesPath }} {{- if $config.nemoModel }} --nemo_model={{ $config.nemoModel }}{{ end }} --checkpoint_folder={{ $config.checkpointFolder }} --checkpoint_name={{ $config.checkpointName }} --hparams_file=/config/hparams.yaml'
+        imagePullPolicy: Always
+        resources:
+          requests:
+            nvidia.com/gpu: {{ .Values.image.gpuNum }}
+          limits:
+            nvidia.com/gpu: {{ .Values.image.gpuNum }}
+        volumeMounts:
+        - mountPath: {{ $config.NFSPath }}
+          name: workspace
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /config
+          name: evaluation-config
+      restartPolicy: Never
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+
+      volumes:
+      - name: workspace
+        nfs:
+          server: {{ $config.NFSServer }}
+          path: {{ $config.NFSPath }}
+
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ $config.shmSize }}
+
+      - configMap:
+          name: evaluation-config
+        name: evaluation-config

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/evaluation/values.yaml
@@ -1,0 +1,73 @@
+image:
+  trainingImage: cfg.container
+  pullPolicy: IfNotPresent
+
+  # Insert the name of your container registry pull secret #
+  pullSecret: nvcr.io
+
+  # Insert number of GPUs #
+  gpuNum: 1
+
+trainingConfig:
+  # Specify the amount of shared memory to attach to the Pods #
+  shmSize: 512Gi
+
+  # Insert the address for the NFS server if using NFS for model storage #
+  NFSServer: <Insert NFS server address>
+
+  # Insert the path to save data on the NFS server #
+  NFSPath: <Insert NFS server path>
+
+  # Insert the path to the vocab file #
+  vocabPath: <Insert absolute path to vocab.json file>
+
+  # Insert the path to the merges file #
+  mergesPath: <Insert absolute path to merges.txt file>
+
+  # Insert the path to the results directory #
+  resultsDirectory: <Insert absolute path to the conversion directory>
+
+  # Insert the path to the training directory #
+  trainingDirectory: <Insert the absolute path to the training directory>
+
+  # Insert the path to the launcher_scripts directory #
+  launcherScriptsPath: <Insert the absolute path to the launcher_scripts directory>
+
+  # Insert the TP size #
+  tensorParallelism: <Insert TP size>
+
+  # Insert the PP size #
+  pipelineParallelism: <Insert PP size>
+
+  # Insert evaluation task name #
+  name: <Insert name of evaluation task>
+
+  # Insert name of model to evaluate #
+  model: <Insert name of model to evaluate>
+
+  # Insert which tasks to evaluate #
+  tasks: <Insert tasks to evaluate>
+
+  # Insert path to store downloaded eval data #
+  cacheDir: <Insert path to cache eval data>
+
+  # Insert path to save evaluation results #
+  outputPath: <Insert path to save eval results>
+
+  # Insert batch size for evaluation #
+  batchSize: <Insert batch size>
+
+  # Insert evaluation precision #
+  precision: <Insert precision>
+
+  # Specify the path to the .nemo model if used #
+  nemoModel: <Insert path to .nemo file or "null">
+
+  # Insert path the the training checkpoint directory #
+  checkpointFolder: <Insert path to checkpoint directory>
+
+  # Insert name of checkpoint or "latest" #
+  checkpointName: <Insert checkpoint name>
+
+  # Insert path to the hparams file from the training job #
+  hparamsFile: <Insert path to hparams.yaml file>

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/Chart.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: NeMo Framework Base Model Training
+name: nemo-framework-training
+version: 1.0.0

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/training-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/training-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: training-config
+data:
+  config.yaml: |-
+  {{ (.Files.Glob "config/*hydra.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/training.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/training.yaml
@@ -1,0 +1,71 @@
+{{ $config := .Values.trainingConfig }}
+
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: nlp-training
+  labels:
+    app: nlp-training
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: {{ .Values.image.nodes }}
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: {{ .Values.image.trainingImage }}
+            env:
+              - name: NCCL_AVOID_RECORD_STREAMS
+                value: "1"
+            {{ if eq $config.wandbKey "nil" }}
+            command: ["torchrun"]
+            args:
+              - "--nnodes={{ .Values.image.nodes }}"
+              - "--rdzv-backend=c10d"
+              - "--rdzv-endpoint=nlp-training-worker-0"
+              - "--nproc_per_node={{ .Values.image.numGPUs }}"
+              - "/opt/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py"
+              - "--config-path=/config"
+              - "--config-name=config.yaml"
+            {{ else }}
+            command: ["bash", "-c"]
+            args:
+              - "wandb login {{ $config.wandbKey }} && torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-training-worker-0 --nproc_per_node={{ .Values.image.numGPUs }} /opt/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py --config-path=/config --config-name=config.yaml"
+            {{ end }}
+            imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                add: [ "IPC_LOCK" ]
+            resources:
+              requests:
+                nvidia.com/gpu: {{ .Values.image.numGPUs }}
+                {{ $config.ibResourceName }}: {{ $config.ibCount }}
+              limits:
+                nvidia.com/gpu: {{ .Values.image.numGPUs }}
+                {{ $config.ibResourceName }}: {{ $config.ibCount }}
+            volumeMounts:
+            - mountPath: {{ $config.NFSPath }}
+              name: workspace
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /config
+              name: training-config
+          restartPolicy: Never
+          imagePullSecrets:
+          - name: {{ .Values.image.pullSecret }}
+
+          volumes:
+          - name: workspace
+            nfs:
+              server: {{ $config.NFSServer }}
+              path: {{ $config.NFSPath }}
+
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: {{ $config.shmSize }}
+
+          - configMap:
+              name: training-config
+            name: training-config

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/values.yaml
@@ -1,0 +1,28 @@
+image:
+  trainingImage: cfg.container
+  pullPolicy: IfNotPresent
+
+  # Insert the name of your container registry pull secret #
+  pullSecret: nvcr.io
+
+  numGPUs: training.trainer.devices
+  nodes: training.trainer.num_nodes
+
+trainingConfig:
+  # Specify the amount of shared memory to attach to the Pods #
+  shmSize: 512Gi
+
+  # Insert the address for the NFS server if using NFS for model storage #
+  NFSServer: <Insert NFS server address>
+
+  # Insert the path to save data on the NFS server #
+  NFSPath: <Insert NFS server path>
+
+  # Specify the k8s resource name for IB devices #
+  ibResourceName: nvidia.com/hostdev
+
+  # Specity the number of IB devices to include in pods #
+  ibCount: "8"
+
+  # Specify the WandB API key if using WandB for logging #
+  wandbKey: "nil"

--- a/launcher_scripts/nemo_launcher/core/launchers.py
+++ b/launcher_scripts/nemo_launcher/core/launchers.py
@@ -21,6 +21,8 @@ import re
 import shlex
 import shutil
 import warnings
+from omegaconf import OmegaConf, DictConfig
+import yaml
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
@@ -70,6 +72,7 @@ class AutoLauncher:
             "bcm": SlurmLauncher,
             "bcp": BCPLauncher,
             "interactive": InteractiveLauncher,
+            "k8s": K8SLauncher,
         }
 
 
@@ -114,6 +117,7 @@ class Launcher:
             on interactive cluster, it's a bash file, trigger with bash.
             on slurm cluster, it's a slurm script file, trigger with sbatch.
             on BCP cluster, it's a BCP script file, trigger with bash.
+            on k8s cluster, it's a Helm chart, triggered with helm.
 
         :param List[List[str]] command_groups: Command groups to launch with
         :return: job id on slurm based system otherwise empty string
@@ -429,6 +433,70 @@ class SlurmLauncher(Launcher):
                 "(you may however set the job job_id manually if needed)"
             )
         return output.group("id")
+
+
+class K8SLauncher(Launcher):
+    """
+    K8s job launcher
+    This class is used to hold the parameters to run a job on kubernetes.
+    In practice, it will create a Helm chart in the specified directory for the job
+    and trigger the job with `bash` command.
+
+    :param Union[Path, str] folder: folder for storing job submission/output and logs.
+    :param str job_name: Name of the job, used as job folder name
+    :param Any **kwargs: Parse other cluster parameters required for k8s running,
+        including `nodes`, `ntasks_pernode`, `bcp_launcher`, etc.
+    """
+
+    def __init__(self, folder: Union[Path, str], job_name: str, **kwargs: Any) -> None:
+        super().__init__(folder, job_name)
+        self.parameters = kwargs
+        self.parameters = self._convert_parameters(self.parameters)
+
+    @classmethod
+    def _equivalence_dict(cls):
+        return {
+            "name": "job_name",
+            "nodes": "nnodes",
+            "tasks_per_node": "npernode",
+            "ntasks_per_node": "npernode",
+        }
+
+    def _convert_parameters(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """translate k8s parameter names"""
+        # replace type in some cases
+        eq_dict = self._equivalence_dict()
+        if eq_dict is not None:
+            params = {eq_dict.get(k, k): v for k, v in params.items()}
+        return params
+
+    def _submit_command(self, submission_file_path: Path) -> str:
+        """Launch the submission command"""
+        command_list = self._make_submission_command(submission_file_path)
+        # run
+        job_utils.CommandFunction(command_list, ret_stdout=False, verbose=False)()  # explicit errors
+        return ""
+
+    @staticmethod
+    def _make_submission_command(submission_file_path: Path) -> List[str]:
+        """Make a command to trigger submission script. On a k8s cluster, the script is triggerred with Helm"""
+        return ["bash", str(submission_file_path)]
+
+    def _make_submission_file_text(self, command_groups: List[List[str]]) -> str:
+        """
+        Generate the script to launch the Helm chart.
+        A very simple bash script is generated which runs `helm install` for the
+        Helm chart that was generated.
+
+        :param List[List[str]] command_groups: Command groups to launch with
+        :return: submission script file's text
+        :rtype: str
+        """
+        paths = job_utils.JobPaths(folder=self.folder, job_name=self.job_name)
+        helm_charts = paths.folder / 'k8s_template'
+        job_name = self.job_name.replace('_', '-')
+
+        return f'#!/bin/bash\nhelm install {job_name} {helm_charts}\n'
 
 
 @functools.lru_cache()

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -19,6 +19,7 @@ import logging
 import json
 import re
 from pathlib import Path
+import shutil
 from typing import Any, Dict, List, Optional
 
 import omegaconf
@@ -28,7 +29,7 @@ from nemo_launcher.utils.data_utils.prepare_squad import (
     prepare_squad_for_prompt_learning,
 )
 from nemo_launcher.utils.job_utils import JobPaths
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, DictConfig
 
 
 class NemoMegatronStage:
@@ -73,9 +74,14 @@ class NemoMegatronStage:
             self.cfg['training']["trainer"]["num_nodes"] = nodes
             logging.info(f"global batch size and number of nodes will change following this schedule:\n {self.nodes_scheduler}")
 
-        stage_cfg_path = NemoMegatronStage.save_stage_hydra_config(self.stage_cfg, job_path)
+        stage_cfg_path = NemoMegatronStage.save_stage_hydra_config(self.stage_cfg, job_path, self.cfg)
         # Make cluster parameters
         cluster_parameters = self._make_cluster_parameters(self.cluster)
+        # Make k8s config file if necessary
+        if self.cluster == 'k8s':
+            template_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), f'k8s_templates/{self.stage_name}')
+            self._make_k8s_spec_file(template_root, cluster_parameters, job_path)
+            self._copy_k8s_helm_chart(template_root, job_path)
         # Make command groups
         command_groups = self.make_stage_command_groups(stage_cfg_path)
         # Create launcher
@@ -92,15 +98,30 @@ class NemoMegatronStage:
         results_folder.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
-    def save_stage_hydra_config(stage_cfg: OmegaConf, job_path: JobPaths) -> Path:
+    def save_stage_hydra_config(stage_cfg: OmegaConf, job_path: JobPaths, cfg: OmegaConf) -> Path:
         """
         Interpolate and save hydra config file for current stage
 
         :param OmegaConf stage_cfg: current stage's hydra configuration
         :param JobPaths job_path: JobPaths object
+        :param OmegaConf cfg: base config for job
         :return: path current stage's essential nemo scripts code
         :rtype: Path
         """
+        # Since k8s uses a Helm chart that launches a job based on the Hydra config
+        # file, the Hydra config file that is generated needs to contain all of the
+        # required keys for each stage.
+        if cfg.cluster_type == "k8s":
+            # OmegaConf doesn't allow adding new keys. Temporarily create a dictionary
+            # representation and add the new keys before converting back to an
+            # OmegaConf object.
+            temp_config = OmegaConf.to_object(stage_cfg)
+            temp_config['data_dir'] = cfg.data_dir
+            temp_config['cluster_type'] = cfg.cluster_type
+            temp_config['launcher_scripts_path'] = cfg.launcher_scripts_path
+            temp_config['data_config'] = stage_cfg.run.name
+            stage_cfg = OmegaConf.create(temp_config)
+
         _hydra_interpolation(stage_cfg)
 
         cfg_save_path = job_path.config_file
@@ -138,6 +159,10 @@ class NemoMegatronStage:
             "git rev-parse HEAD",
             f'export PYTHONPATH={self._nemo_code_path}:\${{PYTHONPATH}}',
         ]
+
+    def _make_k8s_spec_file(self, template_root: str, cluster_parameters: Dict, job_path: JobPaths):
+        """Create a yaml spec file for kubernetes jobs"""
+        raise NotImplementedError
 
     # def _make_numa_mapping_command(self) -> List[str]:
     #     """Make a command of numa mapping call"""
@@ -285,6 +310,17 @@ class NemoMegatronStage:
             )
         elif cluster == "interactive":
             cluster_parameters.update(shared_parameters)
+        elif cluster == "k8s":
+            cluster_cfg = cfg.get("cluster")
+            k8s_cfg = {**copy.deepcopy(cluster_cfg)}
+
+            cluster_parameters = {**k8s_cfg}
+            cluster_parameters.update(
+                {
+                    **shared_parameters,
+                    "container_image": container_image,
+                }
+            )
 
         return cluster_parameters
     
@@ -540,6 +576,72 @@ class NeMoStage(NemoMegatronStage):
         if self.cluster == "bcp":
             hydra_override += ["+rank=\${RANK}"]
         return hydra_override
+    
+    def _copy_k8s_helm_chart(self, template_root: str, job_path: JobPaths):
+        """
+        Copy the k8s Helm charts to the results directory.
+
+        :param str template_root: path to where the k8s template files are located
+        :param JobPaths job_path: JobPaths object
+        """
+        template_file = os.path.join(template_root, 'training.yaml')
+        chart_file = os.path.join(template_root, 'Chart.yaml')
+        training_path = Path(job_path.folder / 'k8s_template' / 'templates' / 'training.yaml')
+        training_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path = Path(job_path.folder / 'k8s_template' / 'config')
+        config_path.mkdir(parents=True, exist_ok=True)
+        chart_path = Path(job_path.folder / 'k8s_template' / 'Chart.yaml')
+        training_config_file = os.path.join(template_root, 'training-config.yaml')
+        training_config_path = Path(job_path.folder / 'k8s_template' / 'templates' / 'training-config.yaml')
+        hydra_config_path = Path(job_path.folder / 'k8s_template' / 'config')
+
+        shutil.copy2(template_file, training_path)
+        shutil.copy2(chart_file, chart_path)
+        shutil.copy2(training_config_file, training_config_path)
+        shutil.copy2(job_path.config_file, hydra_config_path)
+
+    def _add_wandb_key_to_chart(self) -> str:
+        """
+        Read the WandB API key file and return it to be placed in the Helm chart.
+
+        :return: a string of the WandB API key.
+        :rtype: str
+        """
+        with open(self.cfg.wandb_api_key_file, "r") as f:
+            wandb_api_key = f.readline().rstrip()
+        return wandb_api_key
+
+    def _make_k8s_spec_file(self, template_root: str, cluster_parameters: Dict, job_path: JobPaths):
+        """
+        Create a spec file for a Kubernetes training job.
+        The spec file is generated based on the parameters in the cluster and training config files.
+
+        :param str template_root: path to where the k8s template files are located
+        :param Dict cluster_parameters: settings specific to the cluster that is being used
+        :param JobPaths job_path: JobPaths object
+        """
+        with open(os.path.join(template_root, 'values.yaml')) as value_file:
+            values_template = OmegaConf.load(value_file)
+
+        values_template.image.trainingImage = cluster_parameters['container_image']
+        values_template.image.pullSecret = cluster_parameters['pull_secret']
+        values_template.image.numGPUs = self.stage_cfg.trainer.devices
+        values_template.image.nodes = self.stage_cfg.trainer.num_nodes
+        values_template.trainingConfig.shmSize = cluster_parameters['shm_size']
+        values_template.trainingConfig.NFSServer = cluster_parameters['nfs_server']
+        values_template.trainingConfig.NFSPath = cluster_parameters['nfs_path']
+        values_template.trainingConfig.ibResourceName = cluster_parameters['ib_resource_name']
+        values_template.trainingConfig.ibCount = cluster_parameters['ib_count']
+
+        if self.cfg.wandb_api_key_file is not None:
+            values_template.trainingConfig.wandbKey = self._add_wandb_key_to_chart()
+
+        k8s_template_path = job_path.folder
+        k8s_template_file = Path(k8s_template_path / 'k8s_template' / 'values.yaml')
+        k8s_template_file.parent.mkdir(parents=True, exist_ok=True)
+
+        conf = OmegaConf.create(values_template)
+        OmegaConf.save(conf, k8s_template_file)
 
     def get_env_vars(self) -> Dict:
         """
@@ -814,6 +916,57 @@ class Conversion(NemoMegatronStage):
             f"{' '.join(checkpoint_override)}"
         )
 
+    def _make_k8s_spec_file(self, template_root: str, cluster_parameters: Dict, job_path: JobPaths):
+        """
+        Create a spec file for a Kubernetes conversion job.
+        The spec file is generated based on the parameters in the cluster and conversion config files.
+
+        :param str template_root: path to where the k8s template files are located
+        :param Dict cluster_parameters: settings specific to the cluster that is being used
+        :param JobPaths job_path: JobPaths object
+        """
+        with open(os.path.join(template_root, 'values.yaml')) as value_file:
+            values_template = OmegaConf.load(value_file)
+
+        num_gpus = self.cfg.conversion.model.pipeline_model_parallel_size * self.cfg.conversion.model.tensor_model_parallel_size
+
+        values_template.image.trainingImage = cluster_parameters['container_image']
+        values_template.image.pullSecret = cluster_parameters['pull_secret']
+        values_template.image.gpuNum = num_gpus
+        values_template.trainingConfig.shmSize = cluster_parameters['shm_size']
+        values_template.trainingConfig.NFSServer = cluster_parameters['nfs_server']
+        values_template.trainingConfig.NFSPath = cluster_parameters['nfs_path']
+        values_template.trainingConfig.vocabPath = self.cfg.conversion.model.vocab_file
+        values_template.trainingConfig.mergesPath = self.cfg.conversion.model.merge_file
+        values_template.trainingConfig.resultsDirectory = str(job_path.folder)
+        values_template.trainingConfig.trainingDirectory = self.cfg.conversion.run.train_dir
+        values_template.trainingConfig.launcherScriptsPath = self.cfg.launcher_scripts_path
+        values_template.trainingConfig.tensorParallelism = self.cfg.conversion.model.tensor_model_parallel_size
+        values_template.trainingConfig.pipelineParallelism = self.cfg.conversion.model.pipeline_model_parallel_size
+
+        k8s_template_path = job_path.folder
+        k8s_template_file = Path(k8s_template_path / 'k8s_template' / 'values.yaml')
+        k8s_template_file.parent.mkdir(parents=True, exist_ok=True)
+
+        conf = OmegaConf.create(values_template)
+        OmegaConf.save(conf, k8s_template_file)
+
+    def _copy_k8s_helm_chart(self, template_root: str, job_path: JobPaths):
+        """
+        Copy the k8s Helm charts to the results directory.
+
+        :param str template_root: path to where the k8s template files are located
+        :param JobPaths job_path: JobPaths object
+        """
+        template_file = os.path.join(template_root, 'conversion.yaml')
+        chart_file = os.path.join(template_root, 'Chart.yaml')
+        conversion_path = Path(job_path.folder / 'k8s_template' / 'templates' / 'conversion.yaml')
+        conversion_path.parent.mkdir(parents=True, exist_ok=True)
+        chart_path = Path(job_path.folder / 'k8s_template' / 'Chart.yaml')
+
+        shutil.copy2(template_file, conversion_path)
+        shutil.copy2(chart_file, chart_path)
+
     def make_stage_command_groups(self, stage_cfg_path: Path) -> List[List[str]]:
         """
         Make the command groups for current stage
@@ -986,6 +1139,77 @@ class EvalHarnessEvaluation(NemoMegatronStage):
         download_command = [f"python3 {code_path}", *args]
         download_command_string = " \\\n  ".join(download_command)
         return download_command_string
+
+    def _make_k8s_spec_file(self, template_root: str, cluster_parameters: Dict, job_path: JobPaths):
+        """
+        Create a spec file for a Kubernetes conversion job.
+        The spec file is generated based on the parameters in the cluster and conversion config files.
+
+        :param str template_root: path to where the k8s template files are located
+        :param Dict cluster_parameters: settings specific to the cluster that is being used
+        :param JobPaths job_path: JobPaths object
+        """
+        with open(os.path.join(template_root, 'values.yaml')) as value_file:
+            values_template = OmegaConf.load(value_file)
+
+        num_gpus = self.cfg.evaluation.model.pipeline_model_parallel_size * self.cfg.evaluation.model.tensor_model_parallel_size
+
+        values_template.image.trainingImage = cluster_parameters['container_image']
+        values_template.image.pullSecret = cluster_parameters['pull_secret']
+        values_template.image.gpuNum = num_gpus
+        values_template.trainingConfig.shmSize = cluster_parameters['shm_size']
+        values_template.trainingConfig.NFSServer = cluster_parameters['nfs_server']
+        values_template.trainingConfig.NFSPath = cluster_parameters['nfs_path']
+        values_template.trainingConfig.vocabPath = self.cfg.evaluation.model.vocab_file
+        values_template.trainingConfig.mergesPath = self.cfg.evaluation.model.merge_file
+        values_template.trainingConfig.resultsDirectory = str(job_path.folder)
+        values_template.trainingConfig.trainingDirectory = self.cfg.evaluation.run.train_dir
+        values_template.trainingConfig.launcherScriptsPath = self.cfg.launcher_scripts_path
+        values_template.trainingConfig.tensorParallelism = self.cfg.evaluation.model.tensor_model_parallel_size
+        values_template.trainingConfig.pipelineParallelism = self.cfg.evaluation.model.pipeline_model_parallel_size
+        values_template.trainingConfig.name = self.cfg.evaluation.run.name
+        values_template.trainingConfig.model = self.cfg.evaluation.model.model_type
+        values_template.trainingConfig.cacheDir = os.path.join(self.cfg.data_dir, 'eval_harness_data')
+        values_template.trainingConfig.outputPath = os.path.join(self.cfg.evaluation.run.results_dir,
+                                                                 self.cfg.evaluation.run.eval_name,
+                                                                 'results')
+        values_template.trainingConfig.batchSize = self.cfg.evaluation.model.eval_batch_size
+        values_template.trainingConfig.precision = self.cfg.evaluation.model.precision
+        values_template.trainingConfig.nemoModel = self.cfg.evaluation.model.nemo_model
+        values_template.trainingConfig.checkpointFolder = self.cfg.evaluation.model.checkpoint_folder
+        values_template.trainingConfig.checkpointName = self.cfg.evaluation.model.checkpoint_name
+        values_template.trainingConfig.hparamsFile = self.cfg.evaluation.model.hparams_file
+        values_template.trainingConfig.tasks = self.cfg.evaluation.run.tasks
+
+        k8s_template_path = job_path.folder
+        k8s_template_file = Path(k8s_template_path / 'k8s_template' / 'values.yaml')
+        k8s_template_file.parent.mkdir(parents=True, exist_ok=True)
+
+        conf = OmegaConf.create(values_template)
+        OmegaConf.save(conf, k8s_template_file)
+
+    def _copy_k8s_helm_chart(self, template_root: str, job_path: JobPaths):
+        """
+        Copy the k8s Helm charts to the results directory.
+
+        :param str template_root: path to where the k8s template files are located
+        :param JobPaths job_path: JobPaths object
+        """
+        template_file = os.path.join(template_root, 'evaluation.yaml')
+        chart_file = os.path.join(template_root, 'Chart.yaml')
+        evaluation_path = Path(job_path.folder / 'k8s_template' / 'templates' / 'evaluation.yaml')
+        evaluation_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path = Path(job_path.folder / 'k8s_template' / 'config')
+        config_path.mkdir(parents=True, exist_ok=True)
+        chart_path = Path(job_path.folder / 'k8s_template' / 'Chart.yaml')
+        evaluation_config_file = os.path.join(template_root, 'evaluation-config.yaml')
+        evaluation_config_path = Path(job_path.folder / 'k8s_template' / 'templates' / 'evaluation-config.yaml')
+        hparams_config_path = Path(job_path.folder / 'k8s_template' / 'config')
+
+        shutil.copy2(template_file, evaluation_path)
+        shutil.copy2(chart_file, chart_path)
+        shutil.copy2(evaluation_config_file, evaluation_config_path)
+        shutil.copy2(os.path.join(self.cfg.evaluation.run.train_dir, 'results', 'hparams.yaml'), hparams_config_path)
 
     def make_stage_command_groups(self, stage_cfg_path: Path) -> List[List[str]]:
         """


### PR DESCRIPTION
Adding kubernetes support for preparing datasets and training GPT-based foundation models with NeMo Framework. The kubernetes support creates a Helm chart based off the cluster config settings and each task is launched as a distributed job via Helm. Currently, kubernetes support assumes the following:
  * Recent versions of the GPU, Network, and Kubeflow Operators are installed.
  * InfiniBand adapters are labeled as node resources if running multi-node jobs.
  * The launcher is run from a controller node with access to `kubectl` and `helm` and can launch jobs on the cluster.
  * The controller node has the ability to install various Python dependencies, including Hydra.
  * All data including the launcher scripts and results/checkpoints will be stored on an NFS filer attached to all nodes.

A new k8s cluster setting and config file have been included to allow jobs to run on specific kubernetes cluster.