### PR TITLE
Bugfix raw_dataset_files with custom data

### DIFF
--- a/launcher_scripts/nemo_launcher/core/data_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_stages.py
@@ -599,7 +599,10 @@ class CustomDataPreparation(DataStage):
 
         if data_cfg.get("preprocess_data", False):
             if not isinstance(raw_dataset_files, omegaconf.listconfig.ListConfig):
-                raw_dataset_files = [os.path.join(raw_dataset_files,raw_file) for raw_file in os.listdir(raw_dataset_files)]
+                raw_dataset_files = [
+                    os.path.join(raw_dataset_files, raw_file)
+                    for raw_file in os.listdir(raw_dataset_files)
+                ]
             # Sort list of files in directory by size
             sorted_files = sorted(raw_dataset_files, key=lambda x: os.stat(x).st_size)
             file_sizes = [os.stat(x).st_size for x in sorted_files]

--- a/launcher_scripts/nemo_launcher/core/data_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_stages.py
@@ -599,7 +599,7 @@ class CustomDataPreparation(DataStage):
 
         if data_cfg.get("preprocess_data", False):
             if not isinstance(raw_dataset_files, omegaconf.listconfig.ListConfig):
-                raw_dataset_files = os.listdir(raw_dataset_files)
+                raw_dataset_files = [os.path.join(raw_dataset_files,raw_file) for raw_file in os.listdir(raw_dataset_files)]
             # Sort list of files in directory by size
             sorted_files = sorted(raw_dataset_files, key=lambda x: os.stat(x).st_size)
             file_sizes = [os.stat(x).st_size for x in sorted_files]


### PR DESCRIPTION
I think I found a bug in custom dataset.

When a full path to a directory (i.e. /data/nemo/custom_dataset/c4) is passed which contains .gz files (i.e. i manually downloaded c4 en) this [line](https://github.com/NVIDIA/NeMo-Megatron-Launcher/blob/a5afbe3b8060ceec53c7afaa9138ec8b0b7aa023/launcher_scripts/nemo_launcher/core/data_stages.py#L544C28-L544C28) overrides raw_dataset_files and then fails to call os.stat(x) on line 546.

Steps
1. Download c4 en
2. Set launcher_scripts/conf/data_preparation/generic/custom_dataset.yaml key as below

```
raw_dataset_files: /data/nemo/custom_dataset/c4/en
```
3. Run data perperation step with custom dataset

Error:
```
Traceback (most recent call last):
  File "/home/zlapp/nvai4/launcher_scripts/main.py", line 82, in main
    job_id = stage.run()
  File "/home/zlapp/nvai4/launcher_scripts/nemo_launcher/core/data_stages.py", line 51, in run
    self.setup_folder_and_data()
  File "/home/zlapp/nvai4/launcher_scripts/nemo_launcher/core/data_stages.py", line 546, in setup_folder_and_data
    sorted_files = sorted(raw_dataset_files, key=lambda x: os.stat(x).st_size)
  File "/home/zlapp/nvai4/launcher_scripts/nemo_launcher/core/data_stages.py", line 546, in <lambda>
    sorted_files = sorted(raw_dataset_files, key=lambda x: os.stat(x).st_size)
FileNotFoundError: [Errno 2] No such file or directory: 'c4-train.00904-of-01024.json.gz'
```