### PR TITLE
Accept W&B token directly from BCP secret

### DIFF
--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -42,6 +42,7 @@ container_mounts: # List of additional paths to mount to container. They will be
 container: nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.08.03
 
 wandb_api_key_file: null  # File where the w&B api key is stored. Key must be on the first line.
+wandb_api_bcp_secret_key: null  # For BCP clusters, read the W&B api key directly from the environment variable set as a secret from BCP. The value must match the name of the environment variable in BCP, such as WANDB_TOKEN.
 
 env_vars:
   NCCL_TOPO_FILE: null # Should be a path to an XML file describing the topology

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -161,7 +161,10 @@ class NemoMegatronStage:
         """Make a command of login with w&b api key"""
         cfg = self.cfg
         wandb_cmd = ""
-        if cfg.wandb_api_key_file is not None:
+
+        if cfg.cluster_type == "bcp" and cfg.wandb_api_bcp_secret_key is not None:
+            wandb_cmd = f"wandb login ${cfg.wandb_api_bcp_secret_key}"
+        elif cfg.wandb_api_key_file is not None:
             with open(cfg.wandb_api_key_file, "r") as f:
                 wandb_api_key = f.readline().rstrip()
             wandb_cmd = f"wandb login {wandb_api_key}"

--- a/launcher_scripts/tests/unit_tests/config_tests/test_main_config.py
+++ b/launcher_scripts/tests/unit_tests/config_tests/test_main_config.py
@@ -49,6 +49,7 @@ class TestConfig:
         container: nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.08.03
         
         wandb_api_key_file: null  # File where the w&B api key is stored. Key must be on the first line.
+        wandb_api_bcp_secret_key: null  # For BCP clusters, read the W&B api key directly from the environment variable set as a secret from BCP. The value must match the name of the environment variable in BCP, such as WANDB_TOKEN.
         
         env_vars:
           NCCL_TOPO_FILE: null # Should be a path to an XML file describing the topology


### PR DESCRIPTION
On BCP clusters the W&B token can be specified as a cluster secret that is exposed in the job as an environment variable. Reading the key directly from the EV minimizes steps to get started with W&B on BCP.