### PR TITLE
Support additional tokenizers for custom datasets

### DIFF
--- a/launcher_scripts/conf/data_preparation/generic/custom_dataset.yaml
+++ b/launcher_scripts/conf/data_preparation/generic/custom_dataset.yaml
@@ -26,6 +26,10 @@ bpe_save_dir: ${.custom_dataset_dir}/bpe # Dir to save sentence piece tokenizer 
 preprocess_data: True  # True to preprocess the data from json, jsonl or json.gz files, False otherwise.
 raw_dataset_files: # Either a string (path to dataset folder) or a list (of files)
   - null # Each file should be input json, jsonl or json.gz file
+tokenizer_library: sentencepiece  # Name of the tokenizer library, such as "sentencepiece" or "megatron"
+tokenizer_type: null  # Type of tokenizer to use if not training a tokenizer from scratch, such as "GPT2BPETokenizer"
 tokenizer_model: ${.bpe_save_dir}/${data_preparation.train_tokenizer_args.model_prefix}.model # trained SentencePiece tokenizer model
+vocab_file: null  # Path to a vocab file if using BPE tokenizer. Leave "null" if not using BPE.
+merges_file: null  # Path to a merges file if using BPE tokenizer. Leave "null" if not using BPE.
 preprocess_worker_mapping: ${.custom_dataset_dir}/preprocess_mapping
 preprocessed_dir: ${.custom_dataset_dir}/preprocessed

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/custom_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/custom_dataprep/preprocess.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
 
     workers_per_node = args.workers_per_node  # local world size
     if args.bcp:
-        global_rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", 0))
+        global_rank = int(os.environ.get("RANK", 0))
         task_id = global_rank // workers_per_node
         rank = global_rank % workers_per_node
     else:  # on slurm based platforms

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/custom_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/custom_dataprep/preprocess.py
@@ -50,6 +50,36 @@ if __name__ == "__main__":
         type=int,
     )
     parser.add_argument("--bcp", action="store_true", help="Whether on BCP platform")
+    parser.add_argument(
+        "--vocab-file",
+        default=None,
+        help="If using BPE tokenizer, specify the path to a vocab file. Keep None if not using BPE.",
+        type=str,
+    )
+    parser.add_argument(
+        "--merges-file",
+        default=None,
+        help="If using BPE tokenizer, specify the path to a merges file. Keep None if not using BPE.",
+        type=str,
+    )
+    parser.add_argument(
+        "--tokenizer-library",
+        default="sentencepiece",
+        help="Name of the tokenizer library, such as sentencepiece or megatron",
+        type=str,
+    )
+    parser.add_argument(
+        "--tokenizer-type",
+        default=None,
+        help="Name of the tokenizer type to use, such as GPT2BPETokenizer",
+        type=str,
+    )
+    parser.add_argument(
+        "--dataset-impl",
+        default="mmap",
+        help="Specify how the dataset is stored and will be processed.",
+        type=str,
+    )
     args, other_args = parser.parse_known_args()
 
     workers_per_node = args.workers_per_node  # local world size
@@ -82,12 +112,25 @@ if __name__ == "__main__":
         print(
             f" ****** Task ID {task_id:02d} Rank {rank:02d} starts to preprocess {os.path.basename(split)}..."
         )
-        input_arg = ["--input", split]
-        output_arg = [
-            "--output-prefix",
-            os.path.join(args.output_path, os.path.basename(split)),
+        input_arg = split
+        output_arg = os.path.join(args.output_path, os.path.basename(split))
+
+        flags = [
+            f"--input={split}",
+            f"--output-prefix={output_arg}",
+            f"--dataset-impl={args.dataset_impl}",
+            f"--tokenizer-library={args.tokenizer_library}",
+            f"--tokenizer-type={args.tokenizer_type}",
         ]
-        subprocess.check_call(cmd + input_arg + output_arg + other_args)
+
+        if args.vocab_file and args.merges_file:
+            flags += [
+                f"--vocab={args.vocab_file}",
+                f"--merge-file={args.merges_file}",
+                f"--append-eod",
+            ]
+
+        subprocess.check_call(cmd + flags + other_args)
         print(
             f" ****** Task ID {task_id:02d} Rank {rank:02d} finished preprocessing {os.path.basename(split)}..."
         )

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/mc4_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/mc4_dataprep/preprocess.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     workers_per_node = args.workers_per_node  # local world size
     if args.bcp:
-        global_rank = int(os.environ.get("OMPI_COMM_WORLD_RANK", 0))
+        global_rank = int(os.environ.get("RANK", 0))
         task_id = global_rank // workers_per_node
         rank = global_rank % workers_per_node
     else:  # on slurm based platforms

--- a/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
+++ b/launcher_scripts/nemo_launcher/collections/dataprep_scripts/pile_dataprep/preprocess.py
@@ -106,11 +106,16 @@ def main(cfg):
     elif cfg.get("cluster_type") in ["bcp", "k8s"]:
         file_numbers = cfg.get("file_numbers")
         files_list = utils.convert_file_numbers(file_numbers)
-        # Assumes launched via mpirun:
-        #   mpirun -N <nnodes> -npernode 1 ...
-        wrank = int(os.environ.get("OMPI_COMM_WORLD_RANK", 0))
-        wsize = int(os.environ.get("OMPI_COMM_WORLD_SIZE", 0))
-        lrank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", 0))
+        if cfg.get("cluster_type") == "bcp":
+            wrank = int(os.environ.get("RANK", 0))
+            wsize = int(os.environ.get("WORLD_SIZE", 0))
+            lrank = int(os.environ.get("LOCAL_RANK", 0))
+        else:
+            # Assumes launched via mpirun:
+            #   mpirun -N <nnodes> -npernode 1 ...
+            wrank = int(os.environ.get("OMPI_COMM_WORLD_RANK", 0))
+            wsize = int(os.environ.get("OMPI_COMM_WORLD_SIZE", 0))
+            lrank = int(os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK", 0))
 
         if lrank == 0:
             # Compile once per node. Should be one container instance per node.

--- a/launcher_scripts/nemo_launcher/core/data_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_stages.py
@@ -152,7 +152,6 @@ class DataStage(NemoMegatronStage):
         env_vars[
             "PYTHONPATH"
         ] = f"{self._launcher_scripts_path}:${{PYTHONPATH}}"  # Required by pile download
-        env_vars["NGC_ARRAY_TYPE"] = "MPIJob"  # Required by BCP
         setup = [f"export {k}={v}" for k, v in env_vars.items()]
 
         cluster_parameters = {}
@@ -369,7 +368,6 @@ class PileDataPreparation(DataStage):
             return {
                 "nodes": node_array_size,
                 "ntasks_per_node": bcp_preproc_npernode,
-                "bcp_launcher": "'mpirun --allow-run-as-root'",
             }
         return {}
 
@@ -499,7 +497,6 @@ class MC4DataPreparation(DataStage):
             return {
                 "nodes": node_array_size,
                 "ntasks_per_node": ntasks_per_node,
-                "bcp_launcher": "'mpirun --allow-run-as-root'",
             }
         return {}
 
@@ -691,7 +688,6 @@ class CustomDataPreparation(DataStage):
             return {
                 "nodes": node_array_size,
                 "ntasks_per_node": ntasks_per_node,
-                "bcp_launcher": "'mpirun --allow-run-as-root'",
             }
         return {}
 


### PR DESCRIPTION
This update allows the custom dataset preprocessor to handle different types of tokenizers including BPE with GPT2Tokenizer and `sentencepiece`. Users can either train a `sentencepiece` tokenizer alongside the data prep or download an existing tokenizer.

This additionally updates the BCP custom data prep to run as much as 20x faster by launching `bcprun` without `mpirun` to maximize the CPU core usage on all nodes.