### PR TITLE
fix eval_harness download cache-dir

### DIFF
--- a/launcher_scripts/nemo_launcher/collections/eval_harness/download.py
+++ b/launcher_scripts/nemo_launcher/collections/eval_harness/download.py
@@ -26,7 +26,7 @@ def parse_args(parser_main):
     # parser = argparse.ArgumentParser()
     parser = parser_main.add_argument_group(title="download-tasks")
     parser.add_argument("--tasks", default="all_tasks")
-    parser.add_argument("--cache_dir", default="")
+    parser.add_argument("--cache-dir", default="")
     # return parser.parse_args()
     return parser_main
 


### PR DESCRIPTION
This is to fix a issue when run evaluation stage on DGX cloud, 
```
python3 /opt/NeMo-Megatron-Launcher/launcher_scripts/main.py \
             data_dir=/mount_workspace/data  stages=[evaluation] cluster_type=bcp \
             ...
```

the above script would generate bcprun command like this 
```
bcprun --nnodes 1 --npernode 1 -no_redirect  --env 'TRANSFORMERS_OFFLINE=1' --env 'TORCH_NCCL_AVOID_RECORD_STREAMS=1' --env 'NCCL_NVLS_ENABLE=0' --cmd "
  python3 /opt/NeMo-Megatron-Launcher/launcher_scripts/nemo_launcher/collections/eval_harness/download.py \
  --tasks=all_tasks \
  --cache-dir=/mount_workspace/data/eval_harness_data"
```

but the eval datasets are not download to the `cache-dir`, because the download.py instead expected **_underscore_** version of `cache_dir`.
