### PR TITLE
Output STDOUT to Log tab on BCP

### DIFF
--- a/launcher_scripts/nemo_launcher/core/launchers.py
+++ b/launcher_scripts/nemo_launcher/core/launchers.py
@@ -266,7 +266,9 @@ class BCPLauncher(Launcher):
         """Launch the submission command"""
         command_list = self._make_submission_command(submission_file_path)
         # run
-        job_utils.CommandFunction(command_list, verbose=False)()  # explicit errors
+        job_utils.CommandFunction(
+            command_list, ret_stdout=False, verbose=False
+        )()  # explicit errors
 
         return ""
 


### PR DESCRIPTION
On Base Command Platform, the Log tab will display the launched job's STDOUT in addition to the results being piped to a log file.