### PR TITLE
Fix dependency being overwritten with special stage

### DIFF
--- a/launcher_scripts/conf/data_curation/common_crawl/curate_common_crawl.yaml
+++ b/launcher_scripts/conf/data_curation/common_crawl/curate_common_crawl.yaml
@@ -61,4 +61,4 @@ defaults:
 
 special:
   choose_language:
-    language: PL # Change to language of choice based on fastText supported languages: https://fasttext.cc/docs/en/language-identification.html
+    language: EN # Change to language of choice based on fastText supported languages: https://fasttext.cc/docs/en/language-identification.html

--- a/launcher_scripts/conf/data_curation/common_crawl/fasttext_download/fasttext_download.yaml
+++ b/launcher_scripts/conf/data_curation/common_crawl/fasttext_download/fasttext_download.yaml
@@ -9,4 +9,4 @@ run:
 filter_config:
   filter_module: ndc.filter.classifier.filter.FastTextLangId
   params:
-    model_path: <Path to the FasText language id model (e.g., lid.176.bin)>
+    model_path: lid.176.bin # Will be automatically downloaded if it doesn't exist

--- a/launcher_scripts/nemo_launcher/collections/datacuration_scripts/download_fasttext.sh
+++ b/launcher_scripts/nemo_launcher/collections/datacuration_scripts/download_fasttext.sh
@@ -22,12 +22,9 @@
 
 set -eu
 
-res_dir=$1
+res_file=$1
 
 ## Download the fasttext model
-if [ ! -f "${res_dir}/lid.176.bin" ]; then
-  wget https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin -P ${res_dir}
+if [ ! -f ${res_file} ]; then
+  wget https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin -O ${res_file}
 fi
-
-## Replace template text with path to downloaded model
-sed -i "s:<Path to the FasText language id model (e.g., lid.176.bin)>:${res_dir}/lid.176.bin:g" ${res_dir}/fasttext_langid.yaml

--- a/launcher_scripts/nemo_launcher/core/data_curation_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_curation_stages.py
@@ -327,9 +327,14 @@ class FastTextDownload(NemoMegatronStage):
         cluster_parameters = self._make_cluster_parameters(self.cluster)
 
         # Write out the filter configuration as a separate config file
-        filter_cfg = Path(self.get_job_path().results_folder, "fasttext_langid.yaml")
-        omegaconf.OmegaConf.save(self.stage_cfg.get("filter_config"), filter_cfg)
-        self.memory.filter_config_path = filter_cfg
+        results_path = self.get_job_path().results_folder
+        filter_cfg = self.stage_cfg["filter_config"]
+        bin_path = Path(results_path, filter_cfg["params"]["model_path"])
+        filter_cfg_file = Path(results_path, "fasttext_langid.yaml")
+        filter_cfg["params"]["model_path"] = str(bin_path)
+        
+        omegaconf.OmegaConf.save(filter_cfg, filter_cfg_file)
+        self.memory.filter_config_path = filter_cfg_file
 
         # Get the path to download script
         # preface it with bash
@@ -345,7 +350,7 @@ class FastTextDownload(NemoMegatronStage):
         cmd = [
             "bash",
             f"{start_download_script}",
-            str(self.get_job_path().results_folder),
+            str(bin_path),
         ]
         cluster_parameters["setup"] = [shlex.join(cmd)]
 

--- a/launcher_scripts/nemo_launcher/core/data_curation_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_curation_stages.py
@@ -190,6 +190,10 @@ class ChooseLanguage:
         self.memory.data_dir = os.path.join(base_path, lang)
         self.memory.nested_dir = None
 
+        if self.stage_cfg.run["dependency"] != "singleton":
+            job_id = self.stage_cfg.run["dependency"].split(':')[1]
+            return int(job_id)
+
 
 class QualityFiltering(DataCurationSubStage):
     """ DataCurationSubStage for performing quality filtering on documents """

--- a/launcher_scripts/nemo_launcher/core/data_curation_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_curation_stages.py
@@ -161,6 +161,10 @@ class DataCurationSubStage(NemoMegatronStage):
         return sub_stage_config
 
 
+class PipelineException(Exception):
+    pass
+
+
 class InitializeMemory:
     """Dummy stage for initializing the PipelineMemory"""
 
@@ -191,8 +195,12 @@ class ChooseLanguage:
         self.memory.nested_dir = None
 
         if self.stage_cfg.run["dependency"] != "singleton":
-            job_id = self.stage_cfg.run["dependency"].split(':')[1]
+            job_id = self.stage_cfg.run["dependency"].split(":")[1]
             return int(job_id)
+        else:
+            raise PipelineException(
+                "choose_language is only used after separate_by_language"
+            )
 
 
 class QualityFiltering(DataCurationSubStage):

--- a/launcher_scripts/nemo_launcher/core/data_curation_stages.py
+++ b/launcher_scripts/nemo_launcher/core/data_curation_stages.py
@@ -355,7 +355,7 @@ class FastTextDownload(NemoMegatronStage):
         bin_path = Path(results_path, filter_cfg["params"]["model_path"])
         filter_cfg_file = Path(results_path, "fasttext_langid.yaml")
         filter_cfg["params"]["model_path"] = str(bin_path)
-        
+
         omegaconf.OmegaConf.save(filter_cfg, filter_cfg_file)
         self.memory.filter_config_path = filter_cfg_file
 


### PR DESCRIPTION
The choose language stage modifies the pipeline memory but does not actually launch a SLURM job and therefore does not return a `job_id`. This breaks the dependency chain, causing the next job to be run as a singleton instead of depending on the job prior to the choose language stage like it should.

This change keeps the dependency chain that by taking the previous `job_id` and returning that in the run stage. It has been tested by running the `common_crawl/curate_common_crawl` data curation on a small dataset and inspecting the bash scripts that were produced as well. It will also now throw an error if not properly used to ensure the user is able to debug quickly.

Another smaller change has been made to remove a placeholder that the user was not meant to modify. The `<Path to the FasText language id model (e.g., lid.176.bin)>` that was present was not intended to be replaced by the user. It was to be replaced by the `sed` command in the job script. This could easily cause confusion, so it has been removed.