### PR TITLE
Added feature to specify multiple IB resources for trianing k8s template.

### DIFF
--- a/launcher_scripts/conf/cluster/k8s.yaml
+++ b/launcher_scripts/conf/cluster/k8s.yaml
@@ -2,6 +2,7 @@ pull_secret: null  # Kubernetes secret for the container registry to pull privat
 shm_size: 512Gi  # Amount of system memory to allocate in Pods. Should end in "Gi" for gigabytes.
 nfs_server: null  # Hostname or IP address for the NFS server where data is stored.
 nfs_path: null  # Path to store data in the NFS server.
-ib_resource_name: "nvidia.com/hostdev"  # Specify the resource name for IB devices according to kubernetes, such as "nvidia.com/hostdev" for Mellanox IB adapters.
-ib_count: "8"  # Specify the number of IB devices to include per node in each pod.
+ib_resource_name: "nvidia.com/hostdev"  # Specify the resource name for IB devices according to kubernetes, such as "nvidia.com/hostdev" for Mellanox IB adapters. Can also be a list, but must be same length as ib_count
+ib_count: "8"  # Specify the number of IB devices to include per node in each pod. Can also be a list, but must be same length as ib_resource_name
+ib_network_annotation: ""  # Specify the networks as comma separated values
 dns_policy: null  # Specify a dnsPolicy to use in all pods, if necessary

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/training.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/training.yaml
@@ -1,4 +1,6 @@
 {{ $config := .Values.trainingConfig }}
+{{ $ibResourceName := .Values.trainingConfig.ibResourceName }}
+{{ $ibCount := .Values.trainingConfig.ibCount }}
 
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
@@ -42,10 +44,22 @@ spec:
             resources:
               requests:
                 nvidia.com/gpu: {{ .Values.image.numGPUs }}
-                {{ $config.ibResourceName }}: {{ $config.ibCount }}
+                {{- if and (kindIs "slice" $ibResourceName) (kindIs "slice" $ibCount) }}
+                {{- range $i, $val := $ibResourceName }}
+                {{ $val }}: {{ index $ibCount $i }}
+                {{- end }}
+                {{- else }}
+                {{ $ibResourceName }}: {{ $ibCount }}
+                {{- end }}
               limits:
                 nvidia.com/gpu: {{ .Values.image.numGPUs }}
-                {{ $config.ibResourceName }}: {{ $config.ibCount }}
+                {{- if and (kindIs "slice" $ibResourceName) (kindIs "slice" $ibCount) }}
+                {{- range $i, $val := $ibResourceName }}
+                {{ $val }}: {{ index $ibCount $i }}
+                {{- end }}
+                {{- else }}
+                {{ $ibResourceName }}: {{ $ibCount }}
+                {{- end }}
             volumeMounts:
             - mountPath: {{ $config.NFSPath }}
               name: workspace

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/training.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/training.yaml
@@ -1,5 +1,6 @@
 {{ $config := .Values.trainingConfig }}
 {{ $ibResourceName := .Values.trainingConfig.ibResourceName }}
+{{ $ibNetworkAnnotation := .Values.trainingConfig.ibNetworkAnnotation }}
 {{ $ibCount := .Values.trainingConfig.ibCount }}
 
 apiVersion: kubeflow.org/v1
@@ -13,6 +14,11 @@ spec:
     Worker:
       replicas: {{ .Values.image.nodes }}
       template:
+        {{- if $ibNetworkAnnotation }}
+        metadata:
+          annotations:
+            k8s.v1.cni.cncf.io/networks: {{ $ibNetworkAnnotation }}
+        {{- end }}
         spec:
           containers:
           - name: pytorch

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/training/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/training/values.yaml
@@ -18,11 +18,14 @@ trainingConfig:
   # Insert the path to save data on the NFS server #
   NFSPath: <Insert NFS server path>
 
-  # Specify the k8s resource name for IB devices #
+  # Specify the k8s resource name for IB devices. Can be string or list of strings. If list, must be same length as ibCount #
   ibResourceName: nvidia.com/hostdev
 
-  # Specity the number of IB devices to include in pods #
+  # Specity the number of IB devices to include in pods. Can be string or list. If list, must be same length as ibResourceName #
   ibCount: "8"
+
+  # Specity the number of IB networks to include in pods. Should be a comma separated set of networks. #
+  ibNetworkAnnotation: ""
 
   # Specify the WandB API key if using WandB for logging #
   wandbKey: "nil"

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -97,7 +97,9 @@ class NemoMegatronStage:
         command_groups = self.make_stage_command_groups(stage_cfg_path)
         # Create launcher
         launcher = AutoLauncher(
-            folder=job_path.folder, cluster=self.cluster, **cluster_parameters,
+            folder=job_path.folder,
+            cluster=self.cluster,
+            **cluster_parameters,
         )
         job_id = launcher.launch(command_groups=command_groups)
 
@@ -513,7 +515,7 @@ class NemoMegatronStage:
 
     @property
     def _set_ln_sm_margin(self) -> str:
-        """ Set LayerNorm SM margin when using P2P communication overlap to support the overlap with LayerNorm kernel """
+        """Set LayerNorm SM margin when using P2P communication overlap to support the overlap with LayerNorm kernel"""
         vpp = self.cfg.training.model.get("virtual_pipeline_model_parallel_size")
         if (
             self.cfg.training.model.get("overlap_p2p_comm", False)
@@ -530,7 +532,7 @@ class NemoMegatronStage:
 
     @property
     def _skip_ag_overlap(self) -> str:
-        """ Skip TP-AllGather overlap with ring-exchange at (1) bf16 and (2) PP > 1 """
+        """Skip TP-AllGather overlap with ring-exchange at (1) bf16 and (2) PP > 1"""
         if (
             self.cfg.training.model.get("ub_tp_comm_overlap", False)
             and self.cfg.training.model.get("pipeline_model_parallel_size") > 1
@@ -704,7 +706,9 @@ class NeMoStage(NemoMegatronStage):
             "ib_resource_name"
         ]
         values_template.trainingConfig.ibCount = cluster_parameters["ib_count"]
-        values_template.trainingConfig.ibNetworkAnnotation = cluster_parameters["ib_network_annotation"]
+        values_template.trainingConfig.ibNetworkAnnotation = cluster_parameters[
+            "ib_network_annotation"
+        ]
         values_template.trainingConfig.envVars = cluster_parameters["env_vars"]
 
         if cluster_parameters["dns_policy"] is not None:
@@ -919,9 +923,9 @@ class PEFT(NeMoStage):
         """
         Provide the essential nemo code path for running the stage, usually different model types use different nemo scripts.
         For example, `megatron_t5_pretraining.py` for t5 and `megatron_gpt_pretraining.py` for gpt3.
-        
+
         :param str model_type: i.e. `gpt3`, `t5`, `mt5`, etc.
-        :return: path current stage's essential nemo scripts code 
+        :return: path current stage's essential nemo scripts code
         :rtype: Path
         """
 
@@ -961,7 +965,8 @@ class PromptLearning(NeMoStage):
         # Prepare squad dataset
         if task_name == "squad":
             prepare_squad_for_prompt_learning(
-                os.path.join(data_dir, "prompt_data"), self._launcher_scripts_path,
+                os.path.join(data_dir, "prompt_data"),
+                self._launcher_scripts_path,
             )
 
     def _get_nemo_code_path(self, model_type: str) -> Path:
@@ -1221,8 +1226,8 @@ class Conversion(NemoMegatronStage):
 
 class NeMoEvaluation(NeMoStage):
     """
-        Stage class of gpt3/t5/mt5 evaluation with NeMo scripts
-        Including: fine-tuning eval, prompt-learning eval, adapter/ia3 learning eval
+    Stage class of gpt3/t5/mt5 evaluation with NeMo scripts
+    Including: fine-tuning eval, prompt-learning eval, adapter/ia3 learning eval
     """
 
     def setup_stage_vars(self, cfg):
@@ -1258,7 +1263,8 @@ class NeMoEvaluation(NeMoStage):
                 / "nemo_launcher/collections/metric_calculation/squad_metric_calc.py"
             )
             args = create_args_list(
-                pred=pred_file_path, ground_truth=ground_truth_file_path,
+                pred=pred_file_path,
+                ground_truth=ground_truth_file_path,
             )
             split_string = self.stage_cfg.get("split_string", None)
             if split_string:
@@ -1365,7 +1371,10 @@ class EvalHarnessEvaluation(NemoMegatronStage):
             self._launcher_scripts_path
             / "nemo_launcher/collections/eval_harness/download.py"
         )
-        args = create_args_list(tasks=tasks, cache_dir=cache_dir,)
+        args = create_args_list(
+            tasks=tasks,
+            cache_dir=cache_dir,
+        )
         download_command = [f"python3 {code_path}", *args]
         download_command_string = " \\\n  ".join(download_command)
         return download_command_string
@@ -1578,7 +1587,9 @@ def _hydra_interpolation(cfg: OmegaConf) -> None:
 
 
 def create_args_list(
-    hydra: bool = False, replace_underscore: bool = True, **kwargs: Any,
+    hydra: bool = False,
+    replace_underscore: bool = True,
+    **kwargs: Any,
 ) -> List[str]:
     """
     An easy tool function to convert arguments into a list of argument strings.

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -97,9 +97,7 @@ class NemoMegatronStage:
         command_groups = self.make_stage_command_groups(stage_cfg_path)
         # Create launcher
         launcher = AutoLauncher(
-            folder=job_path.folder,
-            cluster=self.cluster,
-            **cluster_parameters,
+            folder=job_path.folder, cluster=self.cluster, **cluster_parameters,
         )
         job_id = launcher.launch(command_groups=command_groups)
 
@@ -954,8 +952,7 @@ class PromptLearning(NeMoStage):
         # Prepare squad dataset
         if task_name == "squad":
             prepare_squad_for_prompt_learning(
-                os.path.join(data_dir, "prompt_data"),
-                self._launcher_scripts_path,
+                os.path.join(data_dir, "prompt_data"), self._launcher_scripts_path,
             )
 
     def _get_nemo_code_path(self, model_type: str) -> Path:
@@ -1252,8 +1249,7 @@ class NeMoEvaluation(NeMoStage):
                 / "nemo_launcher/collections/metric_calculation/squad_metric_calc.py"
             )
             args = create_args_list(
-                pred=pred_file_path,
-                ground_truth=ground_truth_file_path,
+                pred=pred_file_path, ground_truth=ground_truth_file_path,
             )
             split_string = self.stage_cfg.get("split_string", None)
             if split_string:
@@ -1362,10 +1358,7 @@ class EvalHarnessEvaluation(NemoMegatronStage):
             self._launcher_scripts_path
             / "nemo_launcher/collections/eval_harness/download.py"
         )
-        args = create_args_list(
-            tasks=tasks,
-            cache_dir=cache_dir,
-        )
+        args = create_args_list(tasks=tasks, cache_dir=cache_dir,)
         download_command = [f"python3 {code_path}", *args]
         download_command_string = " \\\n  ".join(download_command)
         return download_command_string
@@ -1578,9 +1571,7 @@ def _hydra_interpolation(cfg: OmegaConf) -> None:
 
 
 def create_args_list(
-    hydra: bool = False,
-    replace_underscore: bool = True,
-    **kwargs: Any,
+    hydra: bool = False, replace_underscore: bool = True, **kwargs: Any,
 ) -> List[str]:
     """
     An easy tool function to convert arguments into a list of argument strings.

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -704,6 +704,7 @@ class NeMoStage(NemoMegatronStage):
             "ib_resource_name"
         ]
         values_template.trainingConfig.ibCount = cluster_parameters["ib_count"]
+        values_template.trainingConfig.ibNetworkAnnotation = cluster_parameters["ib_network_annotation"]
         values_template.trainingConfig.envVars = cluster_parameters["env_vars"]
 
         if cluster_parameters["dns_policy"] is not None:


### PR DESCRIPTION
This PR adds the ability to specify multiple IB resources in the pytorchjob by plumbing annotations from `k8s.yaml`. This also adds the missing annotation required to request IB resources for the training stage. It remains backward compatible to allow specifying a single resource without the list notation. Below are example invocations:

- multiple
```
python3 launcher_scripts/main.py \
  cluster=k8s cluster_type=k8s \
  'cluster.ib_resource_name=[nvidia.com/resibp12s0,nvidia.com/resibp186s0]' \
  'cluster.ib_count=[1,1]' cluster.ib_network_annotation=\'ibp12s0,ibp186s0\'
```
- single
```
python3 launcher_scripts/main.py \
  cluster=k8s cluster_type=k8s \
  cluster.ib_resource_name=nvidia.com/hostdev \
  cluster.ib_count=8
```

In a follow up PR, I need to plumb this to all stages with k8s support.