### PR TITLE
Set FP8 AMAX reduction env vars for perf improvement

### DIFF
--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -60,6 +60,8 @@ env_vars:
   TRANSFORMERS_OFFLINE: 1
   TORCH_NCCL_AVOID_RECORD_STREAMS: 1
   NCCL_NVLS_ENABLE: 0
+  NVTE_DP_AMAX_REDUCE_INTERVAL: 0 # Diable FP8 AMAX reduction in the data-parallel domain
+  NVTE_ASYNC_AMAX_REDUCTION: 1 # Enable asynchronous FP8 AMAX reduction
 
 # GPU Mapping
 numa_mapping:

--- a/launcher_scripts/tests/unit_tests/config_tests/test_main_config.py
+++ b/launcher_scripts/tests/unit_tests/config_tests/test_main_config.py
@@ -67,6 +67,8 @@ class TestConfig:
           TRANSFORMERS_OFFLINE: 1
           TORCH_NCCL_AVOID_RECORD_STREAMS: 1
           NCCL_NVLS_ENABLE: 0
+          NVTE_DP_AMAX_REDUCE_INTERVAL: 0 # Diable FP8 AMAX reduction in the data-parallel domain
+          NVTE_ASYNC_AMAX_REDUCTION: 1 # Enable asynchronous FP8 AMAX reduction
         
         # GPU Mapping
         numa_mapping:


### PR DESCRIPTION
1. Disable FP8 AMAX reduction in data-parallel domain
2. Enable async FP8 AMAX reduction (overlap with the following computes)