### PR TITLE
Adds K8s PEFT(LoRa) support to the launcher

### DIFF
--- a/examples/peft/README.md
+++ b/examples/peft/README.md
@@ -1,0 +1,104 @@
+# PEFT
+This example uses the llama2 7b model and finetunes it on squad using the
+LoRa method.
+
+# Prerequisite
+* Helm
+* Kubectl
+* kubeflow/training-operator
+
+## NGC registry secret
+```sh
+kubectl create secret docker-registry ngc-registry --docker-server=nvcr.io --docker-username=\$oauthtoken --docker-password=<NGC KEY HERE>
+```
+
+To try this example, you need to prepare the llama2 7b Nemo checkpoint:
+```sh
+# Assumes huggingface llama2 checkpoint under LOCAL_WORKSPACE
+LOCAL_WORKSPACE=<...>
+NEMO_TRAINING_IMAGE=nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.11
+docker run --rm -it -v $LOCAL_WORKSPACE:/workspace $NEMO_TRAINING_IMAGE \
+  python /opt/NeMo/scripts/nlp_language_modeling/convert_hf_llama_to_nemo.py \
+  --in-file /workspace/llama2_7b \
+  --out-file /workspace/llama2_7b.nemo
+```
+
+## PVC (PersistentVolumeClaim)
+### Prerequisite
+Any launcher command assumes your PVC already exists. Here is an example
+of how to create a dynamic PV from a `StorageClass` setup by your cluster
+admin.
+```sh
+PVC_NAME=nemo-workspace
+STORAGE_CLASS=<...>
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ${STORAGE_CLASS}
+  resources:
+    requests:
+      storage: 50Gi
+EOF
+```
+Then copy `llama2_7b.nemo` into the PVC. Here is how you can do it with a
+busybox container.
+```sh
+PVC_SUBPATH=peft-workspace
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command: ["sleep", "3600"]
+    volumeMounts:
+    - name: workspace
+      mountPath: /workspace
+      subPath: ${PVC_SUBPATH}
+  volumes:
+  - name: workspace
+    persistentVolumeClaim:
+      claimName: ${PVC_NAME}
+EOF
+```
+Then copy it via `kubectl exec`
+```sh
+( cd $LOCAL_WORKSPACE; tar cf - llama2_7b.nemo | kubectl exec -i busybox -- tar xf - -C /workspace )
+```
+Then cleanup the busybox container:
+```sh
+kubectl delete pod/busybox
+```
+### Run
+This will first create a `Job` that downloads squad for you and then
+will create a `PytorchJob` that runs the finetuning workload.
+```sh
+DATA_DIR=/$PVC_SUBPATH RESTORE_FROM_PATH=/$PVC_SUBPATH/llama2_7b.nemo \
+  examples/peft/lora_llama2_7b_2A6000_k8s.sh \
+  cluster.volumes.persistentVolumeClaim.claimName=$PVC_NAME \
+  cluster.volumes.persistentVolumeClaim.subPath=$PVC_SUBPATH \
+  "peft.exp_manager.explicit_log_dir=/$PVC_SUBPATH/\${peft.run.model_train_name}/peft_\${peft.run.task_name}/results"
+```
+
+After this is finished, the experiment logs and checkpoint will be saved in the
+PVC under the value of `peft.exp_manager.explicit_log_dir`, which in this case is
+`/peft-workspace/llama2_7b/peft_*`.
+
+### Cleanup
+```sh
+helm uninstall a6000-7b-2gpu
+```
+
+## HostPath
+Instructions to be available soon!
+
+## NFS
+Instructions to be available soon!

--- a/examples/peft/README.md
+++ b/examples/peft/README.md
@@ -3,8 +3,10 @@ This example uses the llama2 7b model and finetunes it on squad using the
 LoRa method.
 
 # Prerequisite
+Applications:
 * Helm
 * Kubectl
+Operators:
 * kubeflow/training-operator
 
 ## NGC registry secret
@@ -12,6 +14,7 @@ LoRa method.
 kubectl create secret docker-registry ngc-registry --docker-server=nvcr.io --docker-username=\$oauthtoken --docker-password=<NGC KEY HERE>
 ```
 
+## Checkpoint
 To try this example, you need to prepare the llama2 7b Nemo checkpoint:
 ```sh
 # Assumes huggingface llama2 checkpoint under LOCAL_WORKSPACE
@@ -22,6 +25,10 @@ docker run --rm -it -v $LOCAL_WORKSPACE:/workspace $NEMO_TRAINING_IMAGE \
   --in-file /workspace/llama2_7b \
   --out-file /workspace/llama2_7b.nemo
 ```
+
+Other prepared Nemo models:
+* [GPT](https://huggingface.co/nvidia/nemotron-3-8b-base-4k)
+* [T5](https://huggingface.co/nvidia/nemo-megatron-t5-3B) 
 
 ## PVC (PersistentVolumeClaim)
 ### Prerequisite
@@ -42,7 +49,8 @@ spec:
   storageClassName: ${STORAGE_CLASS}
   resources:
     requests:
-      storage: 50Gi
+      # Requesting enough storage for a few experiments
+      storage: 150Gi
 EOF
 ```
 Then copy `llama2_7b.nemo` into the PVC. Here is how you can do it with a
@@ -82,10 +90,11 @@ This will first create a `Job` that downloads squad for you and then
 will create a `PytorchJob` that runs the finetuning workload.
 ```sh
 DATA_DIR=/$PVC_SUBPATH RESTORE_FROM_PATH=/$PVC_SUBPATH/llama2_7b.nemo \
+  HELM_RELEASE_NAME=llama-7b-peft-lora \
   examples/peft/lora_llama2_7b_2A6000_k8s.sh \
   cluster.volumes.persistentVolumeClaim.claimName=$PVC_NAME \
   cluster.volumes.persistentVolumeClaim.subPath=$PVC_SUBPATH \
-  "peft.exp_manager.explicit_log_dir=/$PVC_SUBPATH/\${peft.run.model_train_name}/peft_\${peft.run.task_name}/results"
+  "peft.exp_manager.explicit_log_dir=/$PVC_SUBPATH/\${peft.run.model_train_name}/peft_\${peft.run.name}/results"
 ```
 
 After this is finished, the experiment logs and checkpoint will be saved in the
@@ -94,7 +103,7 @@ PVC under the value of `peft.exp_manager.explicit_log_dir`, which in this case i
 
 ### Cleanup
 ```sh
-helm uninstall a6000-7b-2gpu
+helm uninstall llama-7b-peft-lora
 ```
 
 ## HostPath

--- a/examples/peft/lora_llama2_7b_2A6000_k8s.sh
+++ b/examples/peft/lora_llama2_7b_2A6000_k8s.sh
@@ -6,35 +6,26 @@ set -u
 ##################################################
 # Example invocations:
 #   HOST_PATH=<...>
-#   DATA_DIR=$HOST_PATH/data RESTORE_FROM_PATH=$HOST_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.host_path=$HOST_PATH
+#   DATA_DIR=$HOST_PATH/data RESTORE_FROM_PATH=$HOST_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.volumes.hostPath.path=$HOST_PATH
 #   
 #   NFS_SERVER=<...>
 #   NFS_PATH=<...>
-#   DATA_DIR=$NFS_PATH/data RESTORE_FROM_PATH=$NFS_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.nfs_server=$NFS_SERVER cluster.nfs_path=$NFS_PATH
+#   DATA_DIR=$NFS_PATH/data RESTORE_FROM_PATH=$NFS_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.volumes.nfs.server=$NFS_SERVER cluster.volumes..nfs.path=$NFS_PATH
+#
+#   PVC_NAME=<...>
+#   PVC_SUBPATH=<...>
+#   DATA_DIR=/$PVC_SUBPATH/data RESTORE_FROM_PATH=/$PVC_SUBPATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.volumes.persistentVolumeClaim.claimName=$PVC_NAME cluster.volumes.persistentVolumeClaim.subPath=$PVC_SUBPATH
 ##################################################
 
 #Users should specify the following directories
 NEMO_MEGATRON_LAUNCHER_DIR=$(readlink -f ${SCRIPT_DIR}/../..)
-DATA_DIR=${DATA_DIR:-}
+DATA_DIR=${DATA_DIR}
 RESTORE_FROM_PATH=${RESTORE_FROM_PATH}
 HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-a6000-7b-2gpu}
 
 # peft.model.megatron_amp_O2=false is needed on containers earlier than 23.11 that
 # do not include https://github.com/NVIDIA/NeMo/pull/7971
 TRANSIENT_OVERRIDES="peft.model.megatron_amp_O2=false"
-
-if [[ -z "${DATA_DIR}" ]] || [[ ! -d "${DATA_DIR}" ]]; then
-  cat <<EOF
-DATA_DIR=$DATA_DIR needs to be set to a directory that is available on both this node and the workers.
-
-If hostPath:
-  1. mkdir -p ${DATA_DIR:-\$DATA_DIR}
-  2. DATA_DIR should be a subdir of "cluster.host_path=..."
-If NFS:
-  1. DATA_DIR should be a subdir of "cluster.nfs_path=..."
-EOF
-  exit 1
-fi
 
 # gbs=128 worked for 8 A100
 # gbs=16 should work for 1 A100 assuming 80G, which is total what 2A6000 can handle, but this OOMd so gbs=4
@@ -48,7 +39,6 @@ stages=[peft] \
 peft=llama/squad \
 launcher_scripts_path=${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts \
 data_dir=${DATA_DIR} \
-base_results_dir=${NEMO_MEGATRON_LAUNCHER_DIR}/results \
 peft.run.name="${HELM_RELEASE_NAME}" \
 peft.trainer.num_nodes=1 \
 peft.trainer.devices=2 \

--- a/examples/peft/lora_llama2_7b_2A6000_k8s.sh
+++ b/examples/peft/lora_llama2_7b_2A6000_k8s.sh
@@ -21,7 +21,8 @@ set -u
 NEMO_MEGATRON_LAUNCHER_DIR=$(readlink -f ${SCRIPT_DIR}/../..)
 DATA_DIR=${DATA_DIR}
 RESTORE_FROM_PATH=${RESTORE_FROM_PATH}
-HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-a6000-7b-2gpu}
+HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-llama-7b-peft-lora}
+PEFT_CONFIG=${PEFT_CONFIG:-llama/squad}
 
 # peft.model.megatron_amp_O2=false is needed on containers earlier than 23.11 that
 # do not include https://github.com/NVIDIA/NeMo/pull/7971
@@ -29,14 +30,13 @@ TRANSIENT_OVERRIDES="peft.model.megatron_amp_O2=false"
 
 # gbs=128 worked for 8 A100
 # gbs=16 should work for 1 A100 assuming 80G, which is total what 2A6000 can handle, but this OOMd so gbs=4
-#Users should setup their cluster type in /launcher_scripts/conf/config.yaml
 HYDRA_FULL_ERROR=1 python3 ${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts/main.py \
 cluster=k8s \
 cluster_type=k8s \
 "cluster.ib_count='0'" \
 container=nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.11 \
 stages=[peft] \
-peft=llama/squad \
+peft=${PEFT_CONFIG} \
 launcher_scripts_path=${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts \
 data_dir=${DATA_DIR} \
 peft.run.name="${HELM_RELEASE_NAME}" \

--- a/examples/peft/lora_llama2_7b_2A6000_k8s.sh
+++ b/examples/peft/lora_llama2_7b_2A6000_k8s.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -u
+
+##################################################
+# Example invocations:
+#   HOST_PATH=<...>
+#   DATA_DIR=$HOST_PATH/data RESTORE_FROM_PATH=$HOST_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.host_path=$HOST_PATH
+#   
+#   NFS_SERVER=<...>
+#   NFS_PATH=<...>
+#   DATA_DIR=$NFS_PATH/data RESTORE_FROM_PATH=$NFS_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_2A6000_k8s.sh cluster.nfs_server=$NFS_SERVER cluster.nfs_path=$NFS_PATH
+##################################################
+
+#Users should specify the following directories
+NEMO_MEGATRON_LAUNCHER_DIR=$(readlink -f ${SCRIPT_DIR}/../..)
+DATA_DIR=${DATA_DIR:-}
+RESTORE_FROM_PATH=${RESTORE_FROM_PATH}
+HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-a6000-7b-2gpu}
+
+# peft.model.megatron_amp_O2=false is needed on containers earlier than 23.11 that
+# do not include https://github.com/NVIDIA/NeMo/pull/7971
+TRANSIENT_OVERRIDES="peft.model.megatron_amp_O2=false"
+
+if [[ -z "${DATA_DIR}" ]] || [[ ! -d "${DATA_DIR}" ]]; then
+  cat <<EOF
+DATA_DIR=$DATA_DIR needs to be set to a directory that is available on both this node and the workers.
+
+If hostPath:
+  1. mkdir -p ${DATA_DIR:-\$DATA_DIR}
+  2. DATA_DIR should be a subdir of "cluster.host_path=..."
+If NFS:
+  1. DATA_DIR should be a subdir of "cluster.nfs_path=..."
+EOF
+  exit 1
+fi
+
+# gbs=128 worked for 8 A100
+# gbs=16 should work for 1 A100 assuming 80G, which is total what 2A6000 can handle, but this OOMd so gbs=4
+#Users should setup their cluster type in /launcher_scripts/conf/config.yaml
+HYDRA_FULL_ERROR=1 python3 ${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts/main.py \
+cluster=k8s \
+cluster_type=k8s \
+"cluster.ib_count='0'" \
+container=nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.11 \
+stages=[peft] \
+peft=llama/squad \
+launcher_scripts_path=${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts \
+data_dir=${DATA_DIR} \
+base_results_dir=${NEMO_MEGATRON_LAUNCHER_DIR}/results \
+peft.run.name="${HELM_RELEASE_NAME}" \
+peft.trainer.num_nodes=1 \
+peft.trainer.devices=2 \
+peft.model.global_batch_size=2 \
+peft.model.micro_batch_size=1 \
+peft.model.restore_from_path=$RESTORE_FROM_PATH \
+$TRANSIENT_OVERRIDES \
+$@
+
+cat <<EOF
+To run again, you need to clean up the helm chart that was just deployed.
+
+  $ helm uninstall ${HELM_RELEASE_NAME}
+EOF
+

--- a/launcher_scripts/conf/cluster/k8s.yaml
+++ b/launcher_scripts/conf/cluster/k8s.yaml
@@ -1,7 +1,8 @@
-pull_secret: null  # Kubernetes secret for the container registry to pull private containers.
+pull_secret: ngc-registry  # Kubernetes secret for the container registry to pull private containers.
 shm_size: 512Gi  # Amount of system memory to allocate in Pods. Should end in "Gi" for gigabytes.
 nfs_server: null  # Hostname or IP address for the NFS server where data is stored.
 nfs_path: null  # Path to store data in the NFS server.
+host_path: null # Used mainly for testing. If host_path is present, then nfs_* args are ignored
 ib_resource_name: "nvidia.com/hostdev"  # Specify the resource name for IB devices according to kubernetes, such as "nvidia.com/hostdev" for Mellanox IB adapters.
 ib_count: "8"  # Specify the number of IB devices to include per node in each pod.
 dns_policy: null  # Specify a dnsPolicy to use in all pods, if necessary

--- a/launcher_scripts/conf/cluster/k8s.yaml
+++ b/launcher_scripts/conf/cluster/k8s.yaml
@@ -1,8 +1,23 @@
 pull_secret: ngc-registry  # Kubernetes secret for the container registry to pull private containers.
 shm_size: 512Gi  # Amount of system memory to allocate in Pods. Should end in "Gi" for gigabytes.
-nfs_server: null  # Hostname or IP address for the NFS server where data is stored.
-nfs_path: null  # Path to store data in the NFS server.
-host_path: null # Used mainly for testing. If host_path is present, then nfs_* args are ignored
+volumes:
+  nfs:
+    server: ${...nfs_server}
+    path: ${...nfs_path}  # path is mirrored into pod
+  # Only suitable for 1 node clusters where all workers have this path mounted/available
+  hostPath:
+    # Path on the host
+    path: null  # path is mirrored into pod
+    # https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-volume-types
+    # Directory = errors if does not exist
+    type: "Directory"
+  persistentVolumeClaim:
+    # This claim should be created before running
+    claimName: null
+    subPath: null  # path is mirrored into pod (no leading slash b/c relative to root)
+# NOTE: These args will soon be deprecated
+nfs_server: null
+nfs_path: null
 ib_resource_name: "nvidia.com/hostdev"  # Specify the resource name for IB devices according to kubernetes, such as "nvidia.com/hostdev" for Mellanox IB adapters.
 ib_count: "8"  # Specify the number of IB devices to include per node in each pod.
 dns_policy: null  # Specify a dnsPolicy to use in all pods, if necessary

--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -29,6 +29,7 @@ stages:
   - conversion
   #- prompt_learning
   #- adapter_learning
+  #- peft
   #- ia3_learning
   #- evaluation
   #- export

--- a/launcher_scripts/conf/peft/gpt3/squad.yaml
+++ b/launcher_scripts/conf/peft/gpt3/squad.yaml
@@ -25,13 +25,13 @@ trainer:
   gradient_clip_val: 1.0
 
 exp_manager:
-  explicit_log_dir: null
+  explicit_log_dir: ${peft.run.results_dir}/results
   exp_dir: null
   name: ${peft.name}
   create_wandb_logger: False
   wandb_logger_kwargs:
-    project: null
-    name: null
+    project: nemo_gpt3_${peft.run.task_name}
+    name: ${peft.run.name}
   resume_if_exists: True
   resume_ignore_no_checkpoint: True
   create_checkpoint_callback: True
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter,ia3, or ptuning
+    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training

--- a/launcher_scripts/conf/peft/gpt3/squad.yaml
+++ b/launcher_scripts/conf/peft/gpt3/squad.yaml
@@ -8,13 +8,13 @@ run:
   model_train_name: gpt3_5b
   convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
-  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
+  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.name}
 
 trainer:
   devices: 1
   accelerator: gpu
   num_nodes: 1
-  precision: 16
+  precision: bf16
   logger: False # logger provided by exp_manager
   enable_checkpointing: False
   use_distributed_sampler: False
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
+    peft_scheme: "lora"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training
@@ -131,7 +131,8 @@ model:
       #   - /path/to/boolq.jsonl
       # Example of how each dataset is formatted
       # {'input': 'John von Neumann\nVon Neumann made fundamental contributions .... Q: What did the math of artificial viscosity do?', 'output': 'smoothed the shock transition without sacrificing basic physics'}
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data.
+      file_names:
+      - ${data_dir}/squad_data/v1.1/train-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: True
@@ -146,28 +147,31 @@ model:
       #   - 0.5
       #   - 0.25
       #   - 0.25
-      concat_sampling_probabilities: null # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
+      concat_sampling_probabilities:
+      - 1.0 # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
       context_key: 'input'
       label_key: 'output'
       add_eos: True
       add_sep: False
-      add_bos: False
+      add_bos: True
       separate_prompt_and_response_with_newline: False
       truncation_field: "context" # Options: ['context', 'answer']
       index_mapping_dir: null # Path to a directory to write index mapping files.
       prompt_template: "{input} {output}" # fstring to use for assistant prompt. Example: "Q: {input}\nA: {output}"
 
     validation_ds:
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
-      names: null # Names of the corresponding datasets used to log metrics.
+      file_names: 
+      - ${data_dir}/squad_data/v1.1/dev-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
+      names:
+      - ${peft.run.task_name} # Names of the corresponding datasets used to log metrics.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: False
       num_workers: 0
       memmap_workers: ${peft.model.data.train_ds.memmap_workers}
       pin_memory: True
-      max_seq_length: 2048
-      min_seq_length: 1
+      max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+      min_seq_length: ${peft.model.data.train_ds.min_seq_length}
       drop_last: False
       context_key: 'input'
       label_key: 'output'
@@ -194,8 +198,8 @@ model:
         num_workers: 0
         memmap_workers: ${peft.model.data.train_ds.memmap_workers}
         pin_memory: True
-        max_seq_length: 2048
-        min_seq_length: 1
+        max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+        min_seq_length: ${peft.model.data.train_ds.min_seq_length}
         drop_last: False
         context_key: 'input'
         label_key: 'output'

--- a/launcher_scripts/conf/peft/gpt3/squad.yaml
+++ b/launcher_scripts/conf/peft/gpt3/squad.yaml
@@ -6,7 +6,7 @@ run:
   dependency: "singleton"
   convert_name: convert_nemo
   model_train_name: gpt3_5b
-  convert_dir: ${base_results_dir}/${peft.run.model_train_name}/${peft.run.convert_name}
+  convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
   results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
 

--- a/launcher_scripts/conf/peft/llama/squad.yaml
+++ b/launcher_scripts/conf/peft/llama/squad.yaml
@@ -6,7 +6,7 @@ run:
   dependency: "singleton"
   convert_name: convert_nemo
   model_train_name: llama2_7b
-  convert_dir: ${base_results_dir}/${peft.run.model_train_name}/${peft.run.convert_name}
+  convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
   results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
 

--- a/launcher_scripts/conf/peft/llama/squad.yaml
+++ b/launcher_scripts/conf/peft/llama/squad.yaml
@@ -8,7 +8,7 @@ run:
   model_train_name: llama2_7b
   convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
-  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
+  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.name}
 
 trainer:
   devices: 8

--- a/launcher_scripts/conf/peft/llama/squad.yaml
+++ b/launcher_scripts/conf/peft/llama/squad.yaml
@@ -25,13 +25,13 @@ trainer:
   gradient_clip_val: 1.0
 
 exp_manager:
-  explicit_log_dir: null
+  explicit_log_dir: ${peft.run.results_dir}/results
   exp_dir: null
   name: ${peft.name}
   create_wandb_logger: False
   wandb_logger_kwargs:
-    project: null
-    name: null
+    project: nemo_llama2_${peft.run.task_name}
+    name: ${peft.run.name}
   resume_if_exists: True
   resume_ignore_no_checkpoint: True
   create_checkpoint_callback: True
@@ -60,7 +60,7 @@ model:
   
   global_batch_size: 128
   micro_batch_size: 4
-  restore_from_path: ${fine_tuning.run.convert_dir}/results/megatron_llama.nemo # Path to an existing .nemo model you wish to add new tasks to or run inference with
+  restore_from_path: ??? # Path to an existing .nemo model you wish to add new tasks to or run inference with
   resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.
   save_nemo_on_validation_end: False # Saves an inference ready .nemo file every time a checkpoint is saved during training. 
   sync_batch_comm: False
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "lora"  # can be either adapter,ia3, or ptuning
+    peft_scheme: "lora"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training
@@ -163,15 +163,15 @@ model:
       file_names: 
       - ${data_dir}/squad_data/v1.1/dev-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
       names:
-      - ${fine_tuning.run.task_name} # Names of the corresponding datasets used to log metrics.
+      - ${peft.run.task_name} # Names of the corresponding datasets used to log metrics.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: False
       num_workers: 0
       memmap_workers: ${peft.model.data.train_ds.memmap_workers}
       pin_memory: True
-      max_seq_length: ${fine_tuning.model.data.train_ds.max_seq_length}
-      min_seq_length: ${fine_tuning.model.data.train_ds.min_seq_length}
+      max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+      min_seq_length: ${peft.model.data.train_ds.min_seq_length}
       drop_last: False
       context_key: 'input'
       label_key: 'output'
@@ -198,8 +198,8 @@ model:
         num_workers: 0
         memmap_workers: ${peft.model.data.train_ds.memmap_workers}
         pin_memory: True
-        max_seq_length: ${fine_tuning.model.data.train_ds.max_seq_length}
-        min_seq_length: ${fine_tuning.model.data.train_ds.min_seq_length}
+        max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+        min_seq_length: ${peft.model.data.train_ds.min_seq_length}
         drop_last: False
         context_key: 'input'
         label_key: 'output'

--- a/launcher_scripts/conf/peft/t5/squad.yaml
+++ b/launcher_scripts/conf/peft/t5/squad.yaml
@@ -8,13 +8,13 @@ run:
   model_train_name: t5
   convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
-  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
+  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.name}
 
 trainer:
-  devices: 1
+  devices: 8
   accelerator: gpu
   num_nodes: 1
-  precision: 16
+  precision: bf16
   logger: False # logger provided by exp_manager
   enable_checkpointing: False
   use_distributed_sampler: False
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
+    peft_scheme: "lora"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training
@@ -131,7 +131,8 @@ model:
       #   - /path/to/boolq.jsonl
       # Example of how each dataset is formatted
       # {'input': 'John von Neumann\nVon Neumann made fundamental contributions .... Q: What did the math of artificial viscosity do?', 'output': 'smoothed the shock transition without sacrificing basic physics'}
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data.
+      file_names:
+      - ${data_dir}/squad_data/v1.1/train-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: True
@@ -146,7 +147,8 @@ model:
       #   - 0.5
       #   - 0.25
       #   - 0.25
-      concat_sampling_probabilities: null # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
+      concat_sampling_probabilities:
+      - 1.0 # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
       context_key: 'input'
       label_key: 'output'
       add_eos: True
@@ -158,16 +160,18 @@ model:
       prompt_template: "{input} {output}" # fstring to use for assistant prompt. Example: "Q: {input}\nA: {output}"
 
     validation_ds:
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
-      names: null # Names of the corresponding datasets used to log metrics.
+      file_names: 
+      - ${data_dir}/squad_data/v1.1/dev-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
+      names:
+      - ${peft.run.task_name} # Names of the corresponding datasets used to log metrics.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: False
       num_workers: 0
       memmap_workers: ${peft.model.data.train_ds.memmap_workers}
       pin_memory: True
-      max_seq_length: 2048
-      min_seq_length: 1
+      max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+      min_seq_length: ${peft.model.data.train_ds.min_seq_length}
       drop_last: False
       context_key: 'input'
       label_key: 'output'
@@ -194,8 +198,8 @@ model:
         num_workers: 0
         memmap_workers: ${peft.model.data.train_ds.memmap_workers}
         pin_memory: True
-        max_seq_length: 2048
-        min_seq_length: 1
+        max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+        min_seq_length: ${peft.model.data.train_ds.min_seq_length}
         drop_last: False
         context_key: 'input'
         label_key: 'output'

--- a/launcher_scripts/conf/peft/t5/squad.yaml
+++ b/launcher_scripts/conf/peft/t5/squad.yaml
@@ -6,7 +6,7 @@ run:
   dependency: "singleton"
   convert_name: convert_nemo
   model_train_name: t5
-  convert_dir: ${base_results_dir}/${peft.run.model_train_name}/${peft.run.convert_name}
+  convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
   results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
 

--- a/launcher_scripts/conf/peft/t5/squad.yaml
+++ b/launcher_scripts/conf/peft/t5/squad.yaml
@@ -25,13 +25,13 @@ trainer:
   gradient_clip_val: 1.0
 
 exp_manager:
-  explicit_log_dir: null
+  explicit_log_dir: ${peft.run.results_dir}/results
   exp_dir: null
   name: ${peft.name}
   create_wandb_logger: False
   wandb_logger_kwargs:
-    project: null
-    name: null
+    project: nemo_t5_${peft.run.task_name}
+    name: ${peft.run.name}
   resume_if_exists: True
   resume_ignore_no_checkpoint: True
   create_checkpoint_callback: True
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter,ia3, or ptuning
+    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/Chart.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: NeMo Framework PEFT
+name: nemo-framework-peft
+version: 1.0.0

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: peft-config
+data:
+  config.yaml: |-
+  {{ (.Files.Glob "config/*hydra.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: peft-config
+  name: {{ .Release.Name }}-peft-config
 data:
   config.yaml: |-
   {{ (.Files.Glob "config/*hydra.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
@@ -1,0 +1,66 @@
+{{ $config := .Values.trainingConfig }}
+
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: nlp-peft
+  labels:
+    app: nlp-peft
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: {{ .Values.image.nodes }}
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: {{ .Values.image.trainingImage }}
+            env:
+              {{- range $key, $value := $config.envVars }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end}}
+            command: ["/bin/bash", "-c"]
+            args:
+              - 'cd /opt/NeMo;
+              git rev-parse HEAD;
+              export PYTHONPATH=/opt/NeMo:\${PYTHONPATH};
+              {{ if ne $config.wandbKey "nil" }}
+              wandb login {{ $config.wandbKey }} &&
+              {{ end }}
+              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-peft-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml'
+            imagePullPolicy: Always
+            resources:
+              requests:
+                nvidia.com/gpu: {{ .Values.image.gpuNum }}
+              limits:
+                nvidia.com/gpu: {{ .Values.image.gpuNum }}
+            volumeMounts:
+            - mountPath: {{ $config.NFSPath }}
+              name: workspace
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /config
+              name: peft-config
+          restartPolicy: Never
+          imagePullSecrets:
+          - name: {{ .Values.image.pullSecret }}
+
+          volumes:
+          - name: workspace
+            nfs:
+              server: {{ $config.NFSServer }}
+              path: {{ $config.NFSPath }}
+
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: {{ $config.shmSize }}
+
+          - configMap:
+              name: peft-config
+            name: peft-config
+
+          {{ if ne $config.dnsPolicy "nil" }}
+          dnsPolicy: {{ $config.dnsPolicy }}
+          {{ end }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
@@ -24,11 +24,13 @@ spec:
             args:
               - 'cd /opt/NeMo;
               git rev-parse HEAD;
+              nvidia-smi;
               export PYTHONPATH=/opt/NeMo:\${PYTHONPATH};
               {{ if ne $config.wandbKey "nil" }}
               wandb login {{ $config.wandbKey }} &&
               {{ end }}
-              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-peft-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml'
+              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-peft-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml
+              '
             imagePullPolicy: Always
             resources:
               requests:
@@ -36,7 +38,7 @@ spec:
               limits:
                 nvidia.com/gpu: {{ .Values.image.gpuNum }}
             volumeMounts:
-            - mountPath: {{ $config.NFSPath }}
+            - mountPath: {{ coalesce $config.hostPath $config.NFSPath }}
               name: workspace
             - mountPath: /dev/shm
               name: dshm
@@ -48,9 +50,16 @@ spec:
 
           volumes:
           - name: workspace
+            {{- if empty $config.hostPath }}
             nfs:
               server: {{ $config.NFSServer }}
               path: {{ $config.NFSPath }}
+            {{- else }}
+            hostPath:
+              path: {{ $config.hostPath }}
+              # Error if this path doesn't exist
+              type: Directory
+            {{ end }}
 
           - name: dshm
             emptyDir:

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
@@ -1,9 +1,90 @@
+{{- define "mychart.volumeMounts" -}}
+# The last 
+- mountPath: {{ coalesce .Values.volumes.hostPath.path .Values.volumes.nfs.path (printf "/%s" .Values.volumes.persistentVolumeClaim.subPath) }}
+  name: workspace
+  {{- if .Values.volumes.persistentVolumeClaim.claimName }}
+  subPath: {{ .Values.volumes.persistentVolumeClaim.subPath }}
+  {{- end }}
+- mountPath: /dev/shm
+  name: dshm
+{{- end -}}
+
+{{- define "mychart.volumes" -}}
+- name: workspace
+  {{- if .Values.volumes.nfs.server }}
+  nfs:
+    server: {{ .Values.volumes.nfs.server }}
+    path: {{ .Values.volumes.nfs.path }}
+  {{- else if .Values.volumes.hostPath.path }}
+  hostPath:
+    path: {{ .Values.volumes.hostPath.path }}
+    type: {{ .Values.volumes.hostPath.type }}
+  {{- else if .Values.volumes.persistentVolumeClaim.claimName }}
+  persistentVolumeClaim:
+    claimName: {{ .Values.volumes.persistentVolumeClaim.claimName }}
+  {{- else }}
+  {{ fail "Must specify nfs/hostPath/pvc" }}
+  {{ end }}
+
+- name: dshm
+  emptyDir:
+    medium: Memory
+    sizeLimit: {{ .Values.trainingConfig.shmSize }}
+{{- end -}}
+
 {{ $config := .Values.trainingConfig }}
 
+{{- if .Values.datasetConfig.prepare_task_name }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pre-install-download-{{ .Values.datasetConfig.prepare_task_name }}-{{ .Release.Name }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      containers:
+      - name: download
+        imagePullPolicy: Always
+        image: {{ .Values.image.trainingImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            cd /opt/NeMo-Megatron-Launcher;
+            python -c '
+            {{- if or (eq .Values.datasetConfig.prepare_task_name "squad") (eq .Values.datasetConfig.prepare_task_name "xquad") }}
+            from nemo_launcher.utils.data_utils.prepare_squad import *
+            prepare_squad_for_fine_tuning(data_dir="{{ .Values.datasetConfig.task_data_dir }}")
+            {{- else }}
+            {{- fail (printf "Expected datasetConfig.prepare_task_name to be squad or xquad, but got type=%s" .Values.datasetConfig.prepare_task_name) }}
+            {{- end }}
+            '
+        volumeMounts:
+          {{- include "mychart.volumeMounts" . | nindent 10 }}
+      volumes:
+        {{- include "mychart.volumes" . | nindent 8 }}
+{{- end }}
+---
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
 metadata:
-  name: nlp-peft
+  name: {{ .Release.Name }}
   labels:
     app: nlp-peft
 spec:
@@ -29,7 +110,7 @@ spec:
               {{ if ne $config.wandbKey "nil" }}
               wandb login {{ $config.wandbKey }} &&
               {{ end }}
-              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-peft-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml
+              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint={{ .Release.Name }}-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml
               '
             imagePullPolicy: Always
             resources:
@@ -38,37 +119,18 @@ spec:
               limits:
                 nvidia.com/gpu: {{ .Values.image.gpuNum }}
             volumeMounts:
-            - mountPath: {{ coalesce $config.hostPath $config.NFSPath }}
-              name: workspace
-            - mountPath: /dev/shm
-              name: dshm
-            - mountPath: /config
-              name: peft-config
+              - mountPath: /config
+                name: peft-config
+              {{- include "mychart.volumeMounts" . | nindent 14 }}
           restartPolicy: Never
           imagePullSecrets:
           - name: {{ .Values.image.pullSecret }}
 
           volumes:
-          - name: workspace
-            {{- if empty $config.hostPath }}
-            nfs:
-              server: {{ $config.NFSServer }}
-              path: {{ $config.NFSPath }}
-            {{- else }}
-            hostPath:
-              path: {{ $config.hostPath }}
-              # Error if this path doesn't exist
-              type: Directory
-            {{ end }}
-
-          - name: dshm
-            emptyDir:
-              medium: Memory
-              sizeLimit: {{ $config.shmSize }}
-
-          - configMap:
+            - configMap:
+                name: {{ .Release.Name }}-peft-config
               name: peft-config
-            name: peft-config
+            {{- include "mychart.volumes" . | nindent 12 }}
 
           {{ if ne $config.dnsPolicy "nil" }}
           dnsPolicy: {{ $config.dnsPolicy }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
@@ -1,9 +1,9 @@
 image:
-  trainingImage: cfg.container
+  trainingImage: <training image>
   pullPolicy: IfNotPresent
 
   # Insert the name of your container registry pull secret #
-  pullSecret: nvcr.io
+  pullSecret: ngc-registry
 
   # Insert number of GPUs and nodes #
   gpuNum: 1
@@ -18,6 +18,9 @@ trainingConfig:
 
   # Insert the path to save data on the NFS server #
   NFSPath: <Insert NFS server path>
+
+  # If this is provided, use this instead of NFS. Only suitable for 1 node clusters where all workers have this path mounted/available
+  hostPath: null
 
   # Specify the WandB API key if using WandB for logging #
   wandbKey: "nil"

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
@@ -1,0 +1,32 @@
+image:
+  trainingImage: cfg.container
+  pullPolicy: IfNotPresent
+
+  # Insert the name of your container registry pull secret #
+  pullSecret: nvcr.io
+
+  # Insert number of GPUs and nodes #
+  gpuNum: 1
+  nodes: training.trainer.num_nodes
+
+trainingConfig:
+  # Specify the amount of shared memory to attach to the Pods #
+  shmSize: 512Gi
+
+  # Insert the address for the NFS server if using NFS for model storage #
+  NFSServer: <Insert NFS server address>
+
+  # Insert the path to save data on the NFS server #
+  NFSPath: <Insert NFS server path>
+
+  # Specify the WandB API key if using WandB for logging #
+  wandbKey: "nil"
+
+  # Specify the path to the pre-training script #
+  scriptPath: <Insert path to pre-training script>
+
+  # Insert the dnsPolicy #
+  dnsPolicy: "nil"
+
+  # Specify the environment variables to set in the container #
+  envVars: "nil"

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
@@ -9,18 +9,37 @@ image:
   gpuNum: 1
   nodes: training.trainer.num_nodes
 
+# This config is used only for small datasets that have preparation scripts in NeMo-Megatron-Launcher
+# TODO: make this its own stage
+datasetConfig:
+  # This is the same dir as cfg_data_dir + $task_specific_subdir (e.g., squad_data)
+  task_data_dir: ''
+
+  # If provided, will download this data into cfg.data_dir. Below are the supported values:
+  prepare_task_name: ''  # squad || xquad
+
+# Use only one volume type; they are mutually exclusive.
+# This volume is used for data/checkpoints/results
+volumes:
+  nfs:
+    server: null
+    path: null  # path is mirrored into pod
+  # Only suitable for 1 node clusters where all workers have this path mounted/available
+  hostPath:
+    # Path on the host
+    path: null  # path is mirrored into pod
+    # https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-volume-types
+    # Directory = errors if does not exist
+    type: "Directory"
+  persistentVolumeClaim:
+    # This claim should be created before running
+    claimName: null
+    subPath: null  # path is mirrored into pod (no leading slash b/c relative to root of pvc)
+
 trainingConfig:
+
   # Specify the amount of shared memory to attach to the Pods #
   shmSize: 512Gi
-
-  # Insert the address for the NFS server if using NFS for model storage #
-  NFSServer: <Insert NFS server address>
-
-  # Insert the path to save data on the NFS server #
-  NFSPath: <Insert NFS server path>
-
-  # If this is provided, use this instead of NFS. Only suitable for 1 node clusters where all workers have this path mounted/available
-  hostPath: null
 
   # Specify the WandB API key if using WandB for logging #
   wandbKey: "nil"

--- a/launcher_scripts/nemo_launcher/core/launchers.py
+++ b/launcher_scripts/nemo_launcher/core/launchers.py
@@ -536,7 +536,9 @@ class K8SLauncher(Launcher):
         helm_charts = paths.folder / "k8s_template"
         job_name = self.job_name.replace("_", "-")
 
-        return f"#!/bin/bash\nhelm install {job_name} {helm_charts}\n"
+        # Apply a timeout of 15min in case images take a long time to bring up
+        # or pre-install hooks take a while
+        return f"#!/bin/bash\nhelm install --timeout=15m --wait {job_name} {helm_charts}\n"
 
 
 @functools.lru_cache()

--- a/launcher_scripts/nemo_launcher/core/launchers.py
+++ b/launcher_scripts/nemo_launcher/core/launchers.py
@@ -538,7 +538,9 @@ class K8SLauncher(Launcher):
 
         # Apply a timeout of 15min in case images take a long time to bring up
         # or pre-install hooks take a while
-        return f"#!/bin/bash\nhelm install --timeout=15m --wait {job_name} {helm_charts}\n"
+        return (
+            f"#!/bin/bash\nhelm install --timeout=15m --wait {job_name} {helm_charts}\n"
+        )
 
 
 @functools.lru_cache()

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -97,7 +97,9 @@ class NemoMegatronStage:
         command_groups = self.make_stage_command_groups(stage_cfg_path)
         # Create launcher
         launcher = AutoLauncher(
-            folder=job_path.folder, cluster=self.cluster, **cluster_parameters,
+            folder=job_path.folder,
+            cluster=self.cluster,
+            **cluster_parameters,
         )
         job_id = launcher.launch(command_groups=command_groups)
 
@@ -327,7 +329,10 @@ class NemoMegatronStage:
             )
         elif cluster == "bcp":
             cluster_parameters.update(
-                {**shared_parameters, "env_vars": env_vars,}
+                {
+                    **shared_parameters,
+                    "env_vars": env_vars,
+                }
             )
         elif cluster == "interactive":
             cluster_parameters.update(shared_parameters)
@@ -496,7 +501,7 @@ class NemoMegatronStage:
 
     @property
     def _set_ln_sm_margin(self) -> str:
-        """ Set LayerNorm SM margin when using P2P communication overlap to support the overlap with LayerNorm kernel """
+        """Set LayerNorm SM margin when using P2P communication overlap to support the overlap with LayerNorm kernel"""
         vpp = self.cfg.training.model.get("virtual_pipeline_model_parallel_size")
         if (
             self.cfg.training.model.get("overlap_p2p_comm", False)
@@ -513,7 +518,7 @@ class NemoMegatronStage:
 
     @property
     def _skip_ag_overlap(self) -> str:
-        """ Skip TP-AllGather overlap with ring-exchange at (1) bf16 and (2) PP > 1 """
+        """Skip TP-AllGather overlap with ring-exchange at (1) bf16 and (2) PP > 1"""
         if (
             self.cfg.training.model.get("ub_tp_comm_overlap", False)
             and self.cfg.training.model.get("pipeline_model_parallel_size") > 1
@@ -952,7 +957,9 @@ class PEFT(NeMoStage):
         )
         values_template.trainingConfig.envVars = cluster_parameters["env_vars"]
 
-        values_template.datasetConfig.prepare_task_name = self.stage_cfg.run.get("task_name")
+        values_template.datasetConfig.prepare_task_name = self.stage_cfg.run.get(
+            "task_name"
+        )
         values_template.datasetConfig.task_data_dir = self._task_data_dir
 
         if cluster_parameters["dns_policy"] is not None:
@@ -972,9 +979,9 @@ class PEFT(NeMoStage):
         """
         Provide the essential nemo code path for running the stage, usually different model types use different nemo scripts.
         For example, `megatron_t5_pretraining.py` for t5 and `megatron_gpt_pretraining.py` for gpt3.
-        
+
         :param str model_type: i.e. `gpt3`, `t5`, `mt5`, etc.
-        :return: path current stage's essential nemo scripts code 
+        :return: path current stage's essential nemo scripts code
         :rtype: Path
         """
 
@@ -1012,7 +1019,8 @@ class PromptLearning(NeMoStage):
         # Prepare squad dataset
         if task_name == "squad":
             prepare_squad_for_prompt_learning(
-                os.path.join(data_dir, "prompt_data"), self._launcher_scripts_path,
+                os.path.join(data_dir, "prompt_data"),
+                self._launcher_scripts_path,
             )
 
     def _get_nemo_code_path(self, model_type: str) -> Path:
@@ -1272,8 +1280,8 @@ class Conversion(NemoMegatronStage):
 
 class NeMoEvaluation(NeMoStage):
     """
-        Stage class of gpt3/t5/mt5 evaluation with NeMo scripts
-        Including: fine-tuning eval, prompt-learning eval, adapter/ia3 learning eval
+    Stage class of gpt3/t5/mt5 evaluation with NeMo scripts
+    Including: fine-tuning eval, prompt-learning eval, adapter/ia3 learning eval
     """
 
     def setup_stage_vars(self, cfg):
@@ -1309,7 +1317,8 @@ class NeMoEvaluation(NeMoStage):
                 / "nemo_launcher/collections/metric_calculation/squad_metric_calc.py"
             )
             args = create_args_list(
-                pred=pred_file_path, ground_truth=ground_truth_file_path,
+                pred=pred_file_path,
+                ground_truth=ground_truth_file_path,
             )
             split_string = self.stage_cfg.get("split_string", None)
             if split_string:
@@ -1410,7 +1419,10 @@ class EvalHarnessEvaluation(NemoMegatronStage):
             self._launcher_scripts_path
             / "nemo_launcher/collections/eval_harness/download.py"
         )
-        args = create_args_list(tasks=tasks, cache_dir=cache_dir,)
+        args = create_args_list(
+            tasks=tasks,
+            cache_dir=cache_dir,
+        )
         download_command = [f"python3 {code_path}", *args]
         download_command_string = " \\\n  ".join(download_command)
         return download_command_string
@@ -1622,7 +1634,9 @@ def _hydra_interpolation(cfg: OmegaConf) -> None:
 
 
 def create_args_list(
-    hydra: bool = False, replace_underscore: bool = True, **kwargs: Any,
+    hydra: bool = False,
+    replace_underscore: bool = True,
+    **kwargs: Any,
 ) -> List[str]:
     """
     An easy tool function to convert arguments into a list of argument strings.

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -938,8 +938,11 @@ class PEFT(NeMoStage):
         values_template.image.gpuNum = self.stage_cfg.trainer.devices
         values_template.image.nodes = self.stage_cfg.trainer.num_nodes
         values_template.trainingConfig.shmSize = cluster_parameters["shm_size"]
-        values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
-        values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
+        if cluster_parameters["host_path"]:
+            values_template.trainingConfig.hostPath = cluster_parameters["host_path"]
+        else:
+            values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
+            values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
         values_template.trainingConfig.scriptPath = str(
             self._get_nemo_code_path(choice_model_type)
         )


### PR DESCRIPTION
This work builds upon #138 .

This adds the PEFT k8s stage with configs for gpt3/llama/t5 models and provides some documentation and example scripts.

These PEFT configs have been validated for LoRa on the above models.

## Notable Design changes
* This is the first k8s stage to also use the release name in all the resources created on the cluster. This now makes it possible for someone to submit multiple submissions in parallel. Previously, the would have collided either on disk (local results_dir) or b/c the helm chart deployed a pytorchjob/configmap that had a static name (not dependent on the release name)
* This also introduces a `volumes` key in `k8s.yaml` to specify hostPath, NFS, or PVCs and is backward compatible with the previous support, which only allowed NFS.
* PEFT also did a local download of squad, which was disabled for the k8s launcher and it now only downloads in a pre-install hook. Since the download is fairly quick, it seemed acceptable and adds ~5min to the deployment if the data has never been downloaded to the volume before. If it has, it should finish very quickly < 1min.
* the `cluster` config is now resolved for k8s since the hydra variable references `$(...}` needed to be resolved before passing to helm
* the submission for k8s (`helm install`) now has the `--timeout` and `--wait` flag passed since the 5 minute default was too short