### PR TITLE
Added optional TP overlap config file addition

### DIFF
--- a/launcher_scripts/conf/training/gpt3/175b.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b.yaml
@@ -1,6 +1,6 @@
 defaults:
   - _self_
-  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg: ub_cfg_h100_h12288_tp4_mbs1_seqlen2048
 
 run:
   name: gpt3_175b

--- a/launcher_scripts/conf/training/gpt3/175b.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b.yaml
@@ -1,6 +1,6 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
 run:
   name: gpt3_175b

--- a/launcher_scripts/conf/training/gpt3/175b.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg: ub_cfg_h100_h12288_tp4_mbs1_seqlen2048
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: gpt3_175b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
@@ -5,6 +5,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg: ub_cfg_h100_h12288_tp8_mbs2_seqlen2048
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: gpt3_175b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
@@ -3,7 +3,7 @@
 # convergence (e.g., 300B tokens) is not guaranteed.
 defaults:
   - _self_
-  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg: ub_cfg_h100_h12288_tp8_mbs2_seqlen2048
 
 run:
   name: gpt3_175b

--- a/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
@@ -1,9 +1,9 @@
 # The configurations below provide the best 175B training performance with the NeMo SW stack.
 # We have confirmed the model convergence only with a limited number of tokens and the full model
 # convergence (e.g., 300B tokens) is not guaranteed.
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
 run:
   name: gpt3_175b

--- a/launcher_scripts/conf/training/gpt3/20b.yaml
+++ b/launcher_scripts/conf/training/gpt3/20b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: gpt3_20b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/20b.yaml
+++ b/launcher_scripts/conf/training/gpt3/20b.yaml
@@ -1,6 +1,6 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
 run:
   name: gpt3_20b

--- a/launcher_scripts/conf/training/gpt3/40b.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b.yaml
@@ -1,6 +1,6 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
 run:
   name: gpt3_40b

--- a/launcher_scripts/conf/training/gpt3/40b.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: gpt3_40b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/gpt3/5b.yaml
+++ b/launcher_scripts/conf/training/gpt3/5b.yaml
@@ -1,6 +1,6 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
 run:
   name: gpt3_5b

--- a/launcher_scripts/conf/training/gpt3/5b.yaml
+++ b/launcher_scripts/conf/training/gpt3/5b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: gpt3_5b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/llama/llama2_13b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_13b.yaml
@@ -1,6 +1,7 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
+
 run:
   name: llama2_13b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/llama/llama2_13b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_13b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: llama2_13b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/llama/llama2_70b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_70b.yaml
@@ -1,6 +1,7 @@
-hydra:
-  searchpath:
-    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
+
 run:
   name: llama2_70b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/llama/llama2_70b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_70b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: llama2_70b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/llama/llama2_7b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_7b.yaml
@@ -2,6 +2,10 @@ defaults:
   - _self_
   - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
 
+hydra:
+  searchpath:
+    - file:///opt/NeMo/examples/nlp/language_modeling/conf
+
 run:
   name: llama2_7b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/llama/llama2_7b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_7b.yaml
@@ -1,3 +1,7 @@
+defaults:
+  - _self_
+  - optional tp_overlap@model.ub_tp_comm_overlap_cfg:
+
 run:
   name: llama2_7b
   results_dir: ${base_results_dir}/${.name}

--- a/launcher_scripts/conf/training/tp_overlap/ub_cfg_a100_h12288_tp4_mbs1_seqlen2048.yaml
+++ b/launcher_scripts/conf/training/tp_overlap/ub_cfg_a100_h12288_tp4_mbs1_seqlen2048.yaml
@@ -1,0 +1,53 @@
+# UB communicator configurations
+# Model configs: A100/175B/TP4/MBS1/SeqLen2K/BF16
+    
+# Bulk overlap with AllGather
+qkv_dgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+qkv_wgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+fc1_dgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+fc1_wgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+## Ring-exchange overlap with AllGather
+qkv_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+proj_dgrad:
+  method: ring_exchange
+  aggregate: 0
+
+fc1_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+fc2_dgrad:
+  method: ring_exchange
+  aggregate: 0
+
+# Chunked-collective overlap with ReduceScatter
+proj_fprop:
+  method: pipeline
+  num_sm: 4
+  num_splits: 4
+  set_sm_margin: 0
+
+fc2_fprop:
+  method: pipeline
+  num_sm: 4
+  num_splits: 4
+  set_sm_margin: 0

--- a/launcher_scripts/conf/training/tp_overlap/ub_cfg_a100_h12288_tp4_mbs2_seqlen2048.yaml
+++ b/launcher_scripts/conf/training/tp_overlap/ub_cfg_a100_h12288_tp4_mbs2_seqlen2048.yaml
@@ -1,0 +1,53 @@
+# UB communicator configurations
+# Model configs: A100/175B/TP4/MBS2/SeqLen2K/BF16
+
+# Bulk overlap with AllGather
+qkv_dgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+qkv_wgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+fc1_dgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+fc1_wgrad:
+  method: bulk
+  num_sm: 2
+  set_sm_margin: 0
+
+## Ring-exchange overlap with AllGather
+qkv_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+proj_dgrad:
+  method: ring_exchange
+  aggregate: 0
+
+fc1_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+fc2_dgrad:
+  method: ring_exchange
+  aggregate: 0
+
+# Chunked-collective overlap with ReduceScatter
+proj_fprop:
+  method: pipeline
+  num_sm: 8
+  num_splits: 4
+  set_sm_margin: 0
+
+fc2_fprop:
+  method: pipeline
+  num_sm: 4
+  num_splits: 4
+  set_sm_margin: 0

--- a/launcher_scripts/conf/training/tp_overlap/ub_cfg_h100_h12288_tp4_mbs1_seqlen2048.yaml
+++ b/launcher_scripts/conf/training/tp_overlap/ub_cfg_h100_h12288_tp4_mbs1_seqlen2048.yaml
@@ -1,0 +1,59 @@
+# UB communicator configurations
+# Model configs: H100/175B/TP4/MBS1/SeqLen2K/FP8
+
+# Bulk overlap with AllGather / ReduceScatter
+qkv_dgrad:
+  method: bulk
+  num_sm: 4
+  cga_size: 2
+  set_sm_margin: 0
+
+qkv_wgrad:
+  method: bulk
+  num_sm: 8
+  cga_size: 2
+  set_sm_margin: 0
+
+fc1_dgrad:
+  method: bulk
+  num_sm: 2
+  cga_size: 2
+  set_sm_margin: 0
+
+fc1_wgrad:
+  method: bulk
+  num_sm: 4
+  cga_size: 2
+  set_sm_margin: 0
+
+## Ring-exchange overlap with AllGather
+qkv_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+proj_dgrad:
+  method: ring_exchange
+  aggregate: 0
+
+fc1_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+fc2_dgrad:
+  method: ring_exchange
+  aggregate: 1
+
+# Chunked-collective overlap with ReduceScatter
+proj_fprop:
+  method: pipeline
+  num_sm: 24
+  cga_size: 2
+  num_splits: 4
+  set_sm_margin: 1
+
+fc2_fprop:
+  method: pipeline
+  num_sm: 20
+  cga_size: 2
+  num_splits: 4
+  set_sm_margin: 1

--- a/launcher_scripts/conf/training/tp_overlap/ub_cfg_h100_h12288_tp8_mbs2_seqlen2048.yaml
+++ b/launcher_scripts/conf/training/tp_overlap/ub_cfg_h100_h12288_tp8_mbs2_seqlen2048.yaml
@@ -1,0 +1,59 @@
+# UB communicator configurations
+# Model configs: H100/175B/TP8/MBS2/SeqLen2K/FP8
+
+# Bulk overlap with AllGather
+qkv_dgrad:
+  method: bulk
+  num_sm: 8
+  cga_size: 2
+  set_sm_margin: 0
+
+qkv_wgrad:
+  method: bulk
+  num_sm: 16
+  cga_size: 2
+  set_sm_margin: 0
+
+fc1_dgrad:
+  method: bulk
+  num_sm: 4
+  cga_size: 2
+  set_sm_margin: 0
+
+fc1_wgrad:
+  method: bulk
+  num_sm: 16
+  cga_size: 2
+  set_sm_margin: 0
+
+## Ring-exchange overlap with AllGather
+qkv_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+proj_dgrad:
+  method: ring_exchange
+  aggregate: 1
+
+fc1_fprop:
+  method: ring_exchange
+  aggregate: 0
+
+fc2_dgrad:
+  method: ring_exchange
+  aggregate: 0
+
+# Chunked-collective overlap with ReduceScatter
+proj_fprop:
+  method: pipeline
+  num_sm: 16
+  cga_size: 2
+  num_splits: 4
+  set_sm_margin: 1
+
+fc2_fprop:
+  method: pipeline
+  num_sm: 24
+  cga_size: 2
+  num_splits: 4
+  set_sm_margin: 1

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -785,11 +785,6 @@ class Training(NeMoStage):
                 f"blending_alpha={blending_alpha}"
             )
             hydra_override += [f"model.data.data_prefix=\$({auto_blend_command})"]
-        if self.stage_cfg.model.get("ub_tp_comm_overlap", False):
-            ub_cfg_name = self._get_ub_cfg_override()
-            hydra_override += [
-                f"'+tp_overlap@model.ub_tp_comm_overlap_cfg={ub_cfg_name}'"
-            ]
         if self.stage_cfg.model.get("gc_interval", 0) > 1:
             gc_interval = min(
                 self.stage_cfg.model.get("gc_interval"),
@@ -822,17 +817,6 @@ class Training(NeMoStage):
             / "examples/nlp/language_modeling/megatron_gpt_pretraining.py",
         }
         return model_type_to_code_path[model_type]
-
-    def _get_ub_cfg_override(self) -> str:
-        """
-        Spawn the script to search UB configuration file
-        """
-        tp_size = self.stage_cfg.model.get("tensor_model_parallel_size")
-        hidden_size = self.stage_cfg.model.get("hidden_size")
-        mb_size = self.stage_cfg.model.get("micro_batch_size")
-        seqlen = self.stage_cfg.model.get("encoder_seq_length")
-        cfg_name = f"ub_cfg_\\${{gpu_name:}}_h{hidden_size}_tp{tp_size}_mbs{mb_size}_seqlen{seqlen}"
-        return cfg_name
 
 
 class FineTuning(NeMoStage):


### PR DESCRIPTION
Previously, we were supposed to give dummy config files as Hydra expected some file for the config. We now set the default for this file for all the GPT/LLAMA configs to be optional and will be taken based on the command line if the user wants to tune the config.

If a user wants to add a config, they can add this line below to their Launcher run script:
training/tp_overlap@training.model.ub_tp_comm_overlap_cfg=ub_cfg_h100_h5120_tp2_mbs1_seqlen4096

They should have a YAML file of name ub_cfg_h100_h5120_tp2_mbs1_seqlen4096.yaml in their tp_overlap/ directory adjacent to the LLAMA/GPT conf directory. If they don't add this line, default configs are used.