### PR TITLE
Adds K8s PEFT(LoRa) support to the launcher

### DIFF
--- a/examples/peft/llama/a100/lora_4gpu_k8s.sh
+++ b/examples/peft/llama/a100/lora_4gpu_k8s.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -u
+
+##################################################
+# Example invocations:
+#   HOST_PATH=<...>
+#   DATA_DIR=$HOST_PATH/data RESTORE_FROM_PATH=$HOST_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_4A100_k8s.sh cluster.volumes.hostPath.path=$HOST_PATH
+#   
+#   NFS_SERVER=<...>
+#   NFS_PATH=<...>
+#   DATA_DIR=$NFS_PATH/data RESTORE_FROM_PATH=$NFS_PATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_4A100_k8s.sh cluster.volumes.nfs.server=$NFS_SERVER cluster.volumes..nfs.path=$NFS_PATH
+#
+#   PVC_NAME=<...>
+#   PVC_SUBPATH=<...>
+#   DATA_DIR=/$PVC_SUBPATH/data RESTORE_FROM_PATH=/$PVC_SUBPATH/llama2_7b.nemo ../examples/peft/lora_llama2_7b_4A100_k8s.sh cluster.volumes.persistentVolumeClaim.claimName=$PVC_NAME cluster.volumes.persistentVolumeClaim.subPath=$PVC_SUBPATH
+##################################################
+
+#Users should specify the following directories
+NEMO_MEGATRON_LAUNCHER_DIR=$(readlink -f ${SCRIPT_DIR}/../..)
+DATA_DIR=${DATA_DIR}
+RESTORE_FROM_PATH=${RESTORE_FROM_PATH}
+HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-llama-7b-peft-lora}
+PEFT_CONFIG=${PEFT_CONFIG:-llama/squad}
+
+# peft.model.megatron_amp_O2=false is needed on containers earlier than 23.11 that
+# do not include https://github.com/NVIDIA/NeMo/pull/7971
+TRANSIENT_OVERRIDES="peft.model.megatron_amp_O2=false"
+
+HYDRA_FULL_ERROR=1 python3 ${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts/main.py \
+cluster=k8s \
+cluster_type=k8s \
+"cluster.ib_count='0'" \
+container=nvcr.io/ea-bignlp/ga-participants/nemofw-training:23.11 \
+stages=[peft] \
+peft=${PEFT_CONFIG} \
+launcher_scripts_path=${NEMO_MEGATRON_LAUNCHER_DIR}/launcher_scripts \
+data_dir=${DATA_DIR} \
+peft.run.name="${HELM_RELEASE_NAME}" \
+peft.trainer.num_nodes=1 \
+peft.trainer.devices=4 \
+peft.trainer.max_epochs=null \
+peft.trainer.max_steps=2000 \
+peft.model.global_batch_size=128 \
+peft.model.micro_batch_size=1 \
+peft.model.restore_from_path=$RESTORE_FROM_PATH \
+$TRANSIENT_OVERRIDES \
+$@
+
+cat <<EOF
+To run again, you need to clean up the helm chart that was just deployed.
+
+  $ helm uninstall ${HELM_RELEASE_NAME}
+EOF
+

--- a/launcher_scripts/conf/cluster/k8s.yaml
+++ b/launcher_scripts/conf/cluster/k8s.yaml
@@ -1,5 +1,21 @@
-pull_secret: null  # Kubernetes secret for the container registry to pull private containers.
+pull_secret: ngc-registry  # Kubernetes secret for the container registry to pull private containers.
 shm_size: 512Gi  # Amount of system memory to allocate in Pods. Should end in "Gi" for gigabytes.
+volumes:
+  nfs:
+    server: ${...nfs_server}
+    path: ${...nfs_path}  # path is mirrored into pod
+  # Only suitable for 1 node clusters where all workers have this path mounted/available
+  hostPath:
+    # Path on the host
+    path: null  # path is mirrored into pod
+    # https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-volume-types
+    # Directory = errors if does not exist
+    type: "Directory"
+  persistentVolumeClaim:
+    # This claim should be created before running
+    claimName: null
+    subPath: null  # path is mirrored into pod (no leading slash b/c relative to root)
+# NOTE: These args will soon be deprecated
 nfs_server: null  # Hostname or IP address for the NFS server where data is stored.
 nfs_path: null  # Path to store data in the NFS server.
 ib_resource_name: "nvidia.com/hostdev"  # Specify the resource name for IB devices according to kubernetes, such as "nvidia.com/hostdev" for Mellanox IB adapters. Can also be a list, but must be same length as ib_count

--- a/launcher_scripts/conf/config.yaml
+++ b/launcher_scripts/conf/config.yaml
@@ -34,6 +34,7 @@ stages:
   #- conversion_hf2nemo
   #- prompt_learning
   #- adapter_learning
+  #- peft
   #- ia3_learning
   #- evaluation
   #- export

--- a/launcher_scripts/conf/peft/gpt3/squad.yaml
+++ b/launcher_scripts/conf/peft/gpt3/squad.yaml
@@ -25,13 +25,13 @@ trainer:
   gradient_clip_val: 1.0
 
 exp_manager:
-  explicit_log_dir: null
+  explicit_log_dir: ${peft.run.results_dir}/results
   exp_dir: null
   name: ${peft.name}
   create_wandb_logger: False
   wandb_logger_kwargs:
-    project: null
-    name: null
+    project: nemo_gpt3_${peft.run.task_name}
+    name: ${peft.run.name}
   resume_if_exists: True
   resume_ignore_no_checkpoint: True
   create_checkpoint_callback: True
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter,ia3, or ptuning
+    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training

--- a/launcher_scripts/conf/peft/gpt3/squad.yaml
+++ b/launcher_scripts/conf/peft/gpt3/squad.yaml
@@ -6,15 +6,15 @@ run:
   dependency: "singleton"
   convert_name: convert_nemo
   model_train_name: gpt3_5b
-  convert_dir: ${base_results_dir}/${peft.run.model_train_name}/${peft.run.convert_name}
+  convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
-  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
+  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.name}
 
 trainer:
   devices: 1
   accelerator: gpu
   num_nodes: 1
-  precision: 16
+  precision: bf16
   logger: False # logger provided by exp_manager
   enable_checkpointing: False
   use_distributed_sampler: False
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
+    peft_scheme: "lora"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training
@@ -131,7 +131,8 @@ model:
       #   - /path/to/boolq.jsonl
       # Example of how each dataset is formatted
       # {'input': 'John von Neumann\nVon Neumann made fundamental contributions .... Q: What did the math of artificial viscosity do?', 'output': 'smoothed the shock transition without sacrificing basic physics'}
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data.
+      file_names:
+      - ${data_dir}/squad_data/v1.1/train-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: True
@@ -146,28 +147,31 @@ model:
       #   - 0.5
       #   - 0.25
       #   - 0.25
-      concat_sampling_probabilities: null # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
+      concat_sampling_probabilities:
+      - 1.0 # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
       context_key: 'input'
       label_key: 'output'
       add_eos: True
       add_sep: False
-      add_bos: False
+      add_bos: True
       separate_prompt_and_response_with_newline: False
       truncation_field: "context" # Options: ['context', 'answer']
       index_mapping_dir: null # Path to a directory to write index mapping files.
       prompt_template: "{input} {output}" # fstring to use for assistant prompt. Example: "Q: {input}\nA: {output}"
 
     validation_ds:
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
-      names: null # Names of the corresponding datasets used to log metrics.
+      file_names: 
+      - ${data_dir}/squad_data/v1.1/dev-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
+      names:
+      - ${peft.run.task_name} # Names of the corresponding datasets used to log metrics.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: False
       num_workers: 0
       memmap_workers: ${peft.model.data.train_ds.memmap_workers}
       pin_memory: True
-      max_seq_length: 2048
-      min_seq_length: 1
+      max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+      min_seq_length: ${peft.model.data.train_ds.min_seq_length}
       drop_last: False
       context_key: 'input'
       label_key: 'output'
@@ -194,8 +198,8 @@ model:
         num_workers: 0
         memmap_workers: ${peft.model.data.train_ds.memmap_workers}
         pin_memory: True
-        max_seq_length: 2048
-        min_seq_length: 1
+        max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+        min_seq_length: ${peft.model.data.train_ds.min_seq_length}
         drop_last: False
         context_key: 'input'
         label_key: 'output'

--- a/launcher_scripts/conf/peft/llama/squad.yaml
+++ b/launcher_scripts/conf/peft/llama/squad.yaml
@@ -8,7 +8,7 @@ run:
   model_train_name: llama2_7b
   convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
-  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
+  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.name}
 
 trainer:
   devices: 8

--- a/launcher_scripts/conf/peft/llama/squad.yaml
+++ b/launcher_scripts/conf/peft/llama/squad.yaml
@@ -6,7 +6,7 @@ run:
   dependency: "singleton"
   convert_name: convert_nemo
   model_train_name: llama2_7b
-  convert_dir: ${base_results_dir}/${peft.run.model_train_name}/${peft.run.convert_name}
+  convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
   results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
 
@@ -25,13 +25,13 @@ trainer:
   gradient_clip_val: 1.0
 
 exp_manager:
-  explicit_log_dir: null
+  explicit_log_dir: ${peft.run.results_dir}/results
   exp_dir: null
   name: ${peft.name}
   create_wandb_logger: False
   wandb_logger_kwargs:
-    project: null
-    name: null
+    project: nemo_llama2_${peft.run.task_name}
+    name: ${peft.run.name}
   resume_if_exists: True
   resume_ignore_no_checkpoint: True
   create_checkpoint_callback: True
@@ -88,7 +88,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "lora"  # can be either adapter,ia3, or ptuning
+    peft_scheme: "lora"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training

--- a/launcher_scripts/conf/peft/t5/squad.yaml
+++ b/launcher_scripts/conf/peft/t5/squad.yaml
@@ -25,13 +25,13 @@ trainer:
   gradient_clip_val: 1.0
 
 exp_manager:
-  explicit_log_dir: null
+  explicit_log_dir: ${peft.run.results_dir}/results
   exp_dir: null
   name: ${peft.name}
   create_wandb_logger: False
   wandb_logger_kwargs:
-    project: null
-    name: null
+    project: nemo_t5_${peft.run.task_name}
+    name: ${peft.run.name}
   resume_if_exists: True
   resume_ignore_no_checkpoint: True
   create_checkpoint_callback: True
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter,ia3, or ptuning
+    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training

--- a/launcher_scripts/conf/peft/t5/squad.yaml
+++ b/launcher_scripts/conf/peft/t5/squad.yaml
@@ -6,15 +6,15 @@ run:
   dependency: "singleton"
   convert_name: convert_nemo
   model_train_name: t5
-  convert_dir: ${base_results_dir}/${peft.run.model_train_name}/${peft.run.convert_name}
+  convert_dir: ${base_results_dir}/${.model_train_name}/${.convert_name}
   task_name: "squad"
-  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.task_name}
+  results_dir: ${base_results_dir}/${.model_train_name}/peft_${.name}
 
 trainer:
-  devices: 1
+  devices: 8
   accelerator: gpu
   num_nodes: 1
-  precision: 16
+  precision: bf16
   logger: False # logger provided by exp_manager
   enable_checkpointing: False
   use_distributed_sampler: False
@@ -87,7 +87,7 @@ model:
   ffn_dropout: 0.0
 
   peft:
-    peft_scheme: "adapter"  # can be either adapter, ia3, lora, or ptuning
+    peft_scheme: "lora"  # can be either adapter, ia3, lora, or ptuning
     restore_from_path: null
     
     # Used for adapter peft training
@@ -131,7 +131,8 @@ model:
       #   - /path/to/boolq.jsonl
       # Example of how each dataset is formatted
       # {'input': 'John von Neumann\nVon Neumann made fundamental contributions .... Q: What did the math of artificial viscosity do?', 'output': 'smoothed the shock transition without sacrificing basic physics'}
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data.
+      file_names:
+      - ${data_dir}/squad_data/v1.1/train-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: True
@@ -146,7 +147,8 @@ model:
       #   - 0.5
       #   - 0.25
       #   - 0.25
-      concat_sampling_probabilities: null # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
+      concat_sampling_probabilities:
+      - 1.0 # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
       context_key: 'input'
       label_key: 'output'
       add_eos: True
@@ -158,16 +160,18 @@ model:
       prompt_template: "{input} {output}" # fstring to use for assistant prompt. Example: "Q: {input}\nA: {output}"
 
     validation_ds:
-      file_names: ${peft.model.data.validation_ds.file_names} # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
-      names: null # Names of the corresponding datasets used to log metrics.
+      file_names: 
+      - ${data_dir}/squad_data/v1.1/dev-v1.1_gpt.json # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
+      names:
+      - ${peft.run.task_name} # Names of the corresponding datasets used to log metrics.
       global_batch_size: ${peft.model.global_batch_size}
       micro_batch_size: ${peft.model.micro_batch_size}
       shuffle: False
       num_workers: 0
       memmap_workers: ${peft.model.data.train_ds.memmap_workers}
       pin_memory: True
-      max_seq_length: 2048
-      min_seq_length: 1
+      max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+      min_seq_length: ${peft.model.data.train_ds.min_seq_length}
       drop_last: False
       context_key: 'input'
       label_key: 'output'
@@ -194,8 +198,8 @@ model:
         num_workers: 0
         memmap_workers: ${peft.model.data.train_ds.memmap_workers}
         pin_memory: True
-        max_seq_length: 2048
-        min_seq_length: 1
+        max_seq_length: ${peft.model.data.train_ds.max_seq_length}
+        min_seq_length: ${peft.model.data.train_ds.min_seq_length}
         drop_last: False
         context_key: 'input'
         label_key: 'output'

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/Chart.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: NeMo Framework PEFT
+name: nemo-framework-peft
+version: 1.0.0

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: peft-config
+data:
+  config.yaml: |-
+  {{ (.Files.Glob "config/*hydra.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: peft-config
+  name: {{ .Release.Name }}-peft-config
 data:
   config.yaml: |-
   {{ (.Files.Glob "config/*hydra.yaml").AsConfig | indent 4 }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
@@ -1,0 +1,66 @@
+{{ $config := .Values.trainingConfig }}
+
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: nlp-peft
+  labels:
+    app: nlp-peft
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: {{ .Values.image.nodes }}
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: {{ .Values.image.trainingImage }}
+            env:
+              {{- range $key, $value := $config.envVars }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+              {{- end}}
+            command: ["/bin/bash", "-c"]
+            args:
+              - 'cd /opt/NeMo;
+              git rev-parse HEAD;
+              export PYTHONPATH=/opt/NeMo:\${PYTHONPATH};
+              {{ if ne $config.wandbKey "nil" }}
+              wandb login {{ $config.wandbKey }} &&
+              {{ end }}
+              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-peft-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml'
+            imagePullPolicy: Always
+            resources:
+              requests:
+                nvidia.com/gpu: {{ .Values.image.gpuNum }}
+              limits:
+                nvidia.com/gpu: {{ .Values.image.gpuNum }}
+            volumeMounts:
+            - mountPath: {{ $config.NFSPath }}
+              name: workspace
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /config
+              name: peft-config
+          restartPolicy: Never
+          imagePullSecrets:
+          - name: {{ .Values.image.pullSecret }}
+
+          volumes:
+          - name: workspace
+            nfs:
+              server: {{ $config.NFSServer }}
+              path: {{ $config.NFSPath }}
+
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: {{ $config.shmSize }}
+
+          - configMap:
+              name: peft-config
+            name: peft-config
+
+          {{ if ne $config.dnsPolicy "nil" }}
+          dnsPolicy: {{ $config.dnsPolicy }}
+          {{ end }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/peft.yaml
@@ -1,9 +1,90 @@
+{{- define "mychart.volumeMounts" -}}
+# The last 
+- mountPath: {{ coalesce .Values.volumes.hostPath.path .Values.volumes.nfs.path (printf "/%s" .Values.volumes.persistentVolumeClaim.subPath) }}
+  name: workspace
+  {{- if .Values.volumes.persistentVolumeClaim.claimName }}
+  subPath: {{ .Values.volumes.persistentVolumeClaim.subPath }}
+  {{- end }}
+- mountPath: /dev/shm
+  name: dshm
+{{- end -}}
+
+{{- define "mychart.volumes" -}}
+- name: workspace
+  {{- if .Values.volumes.nfs.server }}
+  nfs:
+    server: {{ .Values.volumes.nfs.server }}
+    path: {{ .Values.volumes.nfs.path }}
+  {{- else if .Values.volumes.hostPath.path }}
+  hostPath:
+    path: {{ .Values.volumes.hostPath.path }}
+    type: {{ .Values.volumes.hostPath.type }}
+  {{- else if .Values.volumes.persistentVolumeClaim.claimName }}
+  persistentVolumeClaim:
+    claimName: {{ .Values.volumes.persistentVolumeClaim.claimName }}
+  {{- else }}
+  {{ fail "Must specify nfs/hostPath/pvc" }}
+  {{ end }}
+
+- name: dshm
+  emptyDir:
+    medium: Memory
+    sizeLimit: {{ .Values.trainingConfig.shmSize }}
+{{- end -}}
+
 {{ $config := .Values.trainingConfig }}
 
+{{- if .Values.datasetConfig.prepare_task_name }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pre-install-download-{{ .Values.datasetConfig.prepare_task_name }}-{{ .Release.Name }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      containers:
+      - name: download
+        imagePullPolicy: Always
+        image: {{ .Values.image.trainingImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            cd /opt/NeMo-Megatron-Launcher;
+            python -c '
+            {{- if or (eq .Values.datasetConfig.prepare_task_name "squad") (eq .Values.datasetConfig.prepare_task_name "xquad") }}
+            from nemo_launcher.utils.data_utils.prepare_squad import *
+            prepare_squad_for_fine_tuning(data_dir="{{ .Values.datasetConfig.task_data_dir }}")
+            {{- else }}
+            {{- fail (printf "Expected datasetConfig.prepare_task_name to be squad or xquad, but got type=%s" .Values.datasetConfig.prepare_task_name) }}
+            {{- end }}
+            '
+        volumeMounts:
+          {{- include "mychart.volumeMounts" . | nindent 10 }}
+      volumes:
+        {{- include "mychart.volumes" . | nindent 8 }}
+{{- end }}
+---
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
 metadata:
-  name: nlp-peft
+  name: {{ .Release.Name }}
   labels:
     app: nlp-peft
 spec:
@@ -24,11 +105,13 @@ spec:
             args:
               - 'cd /opt/NeMo;
               git rev-parse HEAD;
+              nvidia-smi;
               export PYTHONPATH=/opt/NeMo:\${PYTHONPATH};
               {{ if ne $config.wandbKey "nil" }}
               wandb login {{ $config.wandbKey }} &&
               {{ end }}
-              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint=nlp-peft-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml'
+              torchrun --nnodes={{ .Values.image.nodes }} --rdzv-backend=c10d --rdzv-endpoint={{ .Release.Name }}-worker-0 --nproc_per_node={{ .Values.image.gpuNum }} {{ $config.scriptPath }} --config-path=/config --config-name=config.yaml
+              '
             imagePullPolicy: Always
             resources:
               requests:
@@ -36,30 +119,18 @@ spec:
               limits:
                 nvidia.com/gpu: {{ .Values.image.gpuNum }}
             volumeMounts:
-            - mountPath: {{ $config.NFSPath }}
-              name: workspace
-            - mountPath: /dev/shm
-              name: dshm
-            - mountPath: /config
-              name: peft-config
+              - mountPath: /config
+                name: peft-config
+              {{- include "mychart.volumeMounts" . | nindent 14 }}
           restartPolicy: Never
           imagePullSecrets:
           - name: {{ .Values.image.pullSecret }}
 
           volumes:
-          - name: workspace
-            nfs:
-              server: {{ $config.NFSServer }}
-              path: {{ $config.NFSPath }}
-
-          - name: dshm
-            emptyDir:
-              medium: Memory
-              sizeLimit: {{ $config.shmSize }}
-
-          - configMap:
+            - configMap:
+                name: {{ .Release.Name }}-peft-config
               name: peft-config
-            name: peft-config
+            {{- include "mychart.volumes" . | nindent 12 }}
 
           {{ if ne $config.dnsPolicy "nil" }}
           dnsPolicy: {{ $config.dnsPolicy }}

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
@@ -1,0 +1,32 @@
+image:
+  trainingImage: cfg.container
+  pullPolicy: IfNotPresent
+
+  # Insert the name of your container registry pull secret #
+  pullSecret: nvcr.io
+
+  # Insert number of GPUs and nodes #
+  gpuNum: 1
+  nodes: training.trainer.num_nodes
+
+trainingConfig:
+  # Specify the amount of shared memory to attach to the Pods #
+  shmSize: 512Gi
+
+  # Insert the address for the NFS server if using NFS for model storage #
+  NFSServer: <Insert NFS server address>
+
+  # Insert the path to save data on the NFS server #
+  NFSPath: <Insert NFS server path>
+
+  # Specify the WandB API key if using WandB for logging #
+  wandbKey: "nil"
+
+  # Specify the path to the pre-training script #
+  scriptPath: <Insert path to pre-training script>
+
+  # Insert the dnsPolicy #
+  dnsPolicy: "nil"
+
+  # Specify the environment variables to set in the container #
+  envVars: "nil"

--- a/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
+++ b/launcher_scripts/nemo_launcher/core/k8s_templates/peft/values.yaml
@@ -1,23 +1,45 @@
 image:
-  trainingImage: cfg.container
+  trainingImage: <training image>
   pullPolicy: IfNotPresent
 
   # Insert the name of your container registry pull secret #
-  pullSecret: nvcr.io
+  pullSecret: ngc-registry
 
   # Insert number of GPUs and nodes #
   gpuNum: 1
   nodes: training.trainer.num_nodes
 
+# This config is used only for small datasets that have preparation scripts in NeMo-Megatron-Launcher
+# TODO: make this its own stage
+datasetConfig:
+  # This is the same dir as cfg_data_dir + $task_specific_subdir (e.g., squad_data)
+  task_data_dir: ''
+
+  # If provided, will download this data into cfg.data_dir. Below are the supported values:
+  prepare_task_name: ''  # squad || xquad
+
+# Use only one volume type; they are mutually exclusive.
+# This volume is used for data/checkpoints/results
+volumes:
+  nfs:
+    server: null
+    path: null  # path is mirrored into pod
+  # Only suitable for 1 node clusters where all workers have this path mounted/available
+  hostPath:
+    # Path on the host
+    path: null  # path is mirrored into pod
+    # https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-volume-types
+    # Directory = errors if does not exist
+    type: "Directory"
+  persistentVolumeClaim:
+    # This claim should be created before running
+    claimName: null
+    subPath: null  # path is mirrored into pod (no leading slash b/c relative to root of pvc)
+
 trainingConfig:
+
   # Specify the amount of shared memory to attach to the Pods #
   shmSize: 512Gi
-
-  # Insert the address for the NFS server if using NFS for model storage #
-  NFSServer: <Insert NFS server address>
-
-  # Insert the path to save data on the NFS server #
-  NFSPath: <Insert NFS server path>
 
   # Specify the WandB API key if using WandB for logging #
   wandbKey: "nil"

--- a/launcher_scripts/nemo_launcher/core/launchers.py
+++ b/launcher_scripts/nemo_launcher/core/launchers.py
@@ -549,7 +549,9 @@ class K8SLauncher(Launcher):
             sub_command = "template"
         else:
             sub_command = "install"
-        return f"#!/bin/bash\nhelm {sub_command} {job_name} {helm_charts}\n"
+        # Apply a timeout of 15min in case images take a long time to bring up
+        # or pre-install hooks take a while
+        return f"#!/bin/bash\nhelm {sub_command} --timeout=15m --wait {job_name} {helm_charts}\n"
 
 
 @functools.lru_cache()

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -354,6 +354,9 @@ class NemoMegatronStage:
         elif cluster == "interactive":
             cluster_parameters.update(shared_parameters)
         elif cluster == "k8s":
+            # Resolving since there is a dependency between soon-to-be deprecated
+            # cluster.nfs_path which is referenced in cluster.volumes.nfs.path
+            OmegaConf.resolve(cfg.get("cluster"))
             cluster_cfg = cfg.get("cluster")
             k8s_cfg = {**copy.deepcopy(cluster_cfg)}
 
@@ -713,8 +716,7 @@ class NeMoStage(NemoMegatronStage):
         values_template.image.numGPUs = self.stage_cfg.trainer.devices
         values_template.image.nodes = self.stage_cfg.trainer.num_nodes
         values_template.trainingConfig.shmSize = cluster_parameters["shm_size"]
-        values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
-        values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
+        values_template.volumes = cluster_parameters["volumes"]
         values_template.trainingConfig.ibResourceName = cluster_parameters[
             "ib_resource_name"
         ]
@@ -949,10 +951,14 @@ class PEFT(NeMoStage):
             task_name = self.stage_cfg.run.get("task_name")
 
             # Prepare dataset for squad
-            if task_name in ["squad", "xquad"]:
-                prepare_squad_for_fine_tuning(
-                    data_dir=os.path.join(data_dir, "squad_data")
-                )
+            if task_name in ("squad", "xquad"):
+                self._task_data_dir = os.path.join(data_dir, "squad_data")
+                if self.cfg.cluster_type == "k8s":
+                    # Skip downloading since on k8s the data is downloaded in a
+                    # pre-install job since user may not be using a volume type
+                    # that's not available locally, e.g., PVC
+                    return
+                prepare_squad_for_fine_tuning(data_dir=self._task_data_dir)
 
     def _copy_k8s_helm_chart(self, template_root: str, job_path: JobPaths):
         """
@@ -1002,12 +1008,16 @@ class PEFT(NeMoStage):
         values_template.image.gpuNum = self.stage_cfg.trainer.devices
         values_template.image.nodes = self.stage_cfg.trainer.num_nodes
         values_template.trainingConfig.shmSize = cluster_parameters["shm_size"]
-        values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
-        values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
+        values_template.volumes = cluster_parameters["volumes"]
         values_template.trainingConfig.scriptPath = str(
             self._get_nemo_code_path(choice_model_type)
         )
         values_template.trainingConfig.envVars = cluster_parameters["env_vars"]
+
+        values_template.datasetConfig.prepare_task_name = self.stage_cfg.run.get(
+            "task_name"
+        )
+        values_template.datasetConfig.task_data_dir = self._task_data_dir
 
         if cluster_parameters["dns_policy"] is not None:
             values_template.trainingConfig.dnsPolicy = cluster_parameters["dns_policy"]
@@ -1265,8 +1275,7 @@ class Conversion(NemoMegatronStage):
         values_template.image.pullSecret = cluster_parameters["pull_secret"]
         values_template.image.gpuNum = num_gpus
         values_template.trainingConfig.shmSize = cluster_parameters["shm_size"]
-        values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
-        values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
+        values_template.volumes = cluster_parameters["volumes"]
         values_template.trainingConfig.vocabPath = self.cfg.conversion.model.vocab_file
         values_template.trainingConfig.mergesPath = self.cfg.conversion.model.merge_file
         values_template.trainingConfig.resultsDirectory = str(job_path.folder)
@@ -1629,8 +1638,7 @@ class EvalHarnessEvaluation(NemoMegatronStage):
         values_template.image.pullSecret = cluster_parameters["pull_secret"]
         values_template.image.gpuNum = num_gpus
         values_template.trainingConfig.shmSize = cluster_parameters["shm_size"]
-        values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
-        values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
+        values_template.volumes = cluster_parameters["volumes"]
         values_template.trainingConfig.vocabPath = self.cfg.evaluation.model.vocab_file
         values_template.trainingConfig.mergesPath = self.cfg.evaluation.model.merge_file
         values_template.trainingConfig.resultsDirectory = str(job_path.folder)

--- a/launcher_scripts/nemo_launcher/core/stages.py
+++ b/launcher_scripts/nemo_launcher/core/stages.py
@@ -954,6 +954,74 @@ class PEFT(NeMoStage):
                     data_dir=os.path.join(data_dir, "squad_data")
                 )
 
+    def _copy_k8s_helm_chart(self, template_root: str, job_path: JobPaths):
+        """
+        Copy the k8s Helm charts to the results directory.
+
+        :param str template_root: path to where the k8s template files are located
+        :param JobPaths job_path: JobPaths object
+        """
+        template_file = os.path.join(template_root, "peft.yaml")
+        chart_file = os.path.join(template_root, "Chart.yaml")
+        prompt_path = Path(job_path.folder / "k8s_template" / "templates" / "peft.yaml")
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path = Path(job_path.folder / "k8s_template" / "config")
+        config_path.mkdir(parents=True, exist_ok=True)
+        chart_path = Path(job_path.folder / "k8s_template" / "Chart.yaml")
+        prompt_config_file = os.path.join(template_root, "peft-config.yaml")
+        prompt_config_path = Path(
+            job_path.folder / "k8s_template" / "templates" / "peft-config.yaml"
+        )
+        hydra_config_path = Path(job_path.folder / "k8s_template" / "config")
+
+        shutil.copy2(template_file, prompt_path)
+        shutil.copy2(chart_file, chart_path)
+        shutil.copy2(prompt_config_file, prompt_config_path)
+        shutil.copy2(job_path.config_file, hydra_config_path)
+
+    def _make_k8s_spec_file(
+        self, template_root: str, cluster_parameters: Dict, job_path: JobPaths
+    ):
+        """
+        Create a spec file for a Kubernetes PEFT job.
+
+        The spec file is generated based on the parameters in the cluster and
+        PEFT config files.
+
+        :param str template_root: path to where the k8s template files are located
+        :param Dict cluster_parameters: settings specific to the cluster that is being used
+        :param JobPaths job_path: JobPaths object
+        """
+        with open(os.path.join(template_root, "values.yaml")) as value_file:
+            values_template = OmegaConf.load(value_file)
+
+        choice_model_type, _ = self.get_stage_config_choice()
+
+        values_template.image.trainingImage = cluster_parameters["container_image"]
+        values_template.image.pullSecret = cluster_parameters["pull_secret"]
+        values_template.image.gpuNum = self.stage_cfg.trainer.devices
+        values_template.image.nodes = self.stage_cfg.trainer.num_nodes
+        values_template.trainingConfig.shmSize = cluster_parameters["shm_size"]
+        values_template.trainingConfig.NFSServer = cluster_parameters["nfs_server"]
+        values_template.trainingConfig.NFSPath = cluster_parameters["nfs_path"]
+        values_template.trainingConfig.scriptPath = str(
+            self._get_nemo_code_path(choice_model_type)
+        )
+        values_template.trainingConfig.envVars = cluster_parameters["env_vars"]
+
+        if cluster_parameters["dns_policy"] is not None:
+            values_template.trainingConfig.dnsPolicy = cluster_parameters["dns_policy"]
+
+        if self.cfg.wandb_api_key_file is not None:
+            values_template.trainingConfig.wandbKey = self._add_wandb_key_to_chart()
+
+        k8s_template_path = job_path.folder
+        k8s_template_file = Path(k8s_template_path / "k8s_template" / "values.yaml")
+        k8s_template_file.parent.mkdir(parents=True, exist_ok=True)
+
+        conf = OmegaConf.create(values_template)
+        OmegaConf.save(conf, k8s_template_file)
+
     def _get_nemo_code_path(self, model_type: str) -> Path:
         """
         Provide the essential nemo code path for running the stage, usually different model types use different nemo scripts.


### PR DESCRIPTION
Replaces #202 
-------------------
This work builds upon #138 .

This adds the PEFT k8s stage with configs for gpt3/llama/t5 models and provides some documentation and example scripts.

These PEFT configs have been validated for LoRa on the above models.

## Notable Design changes
* This is the first k8s stage to also use the release name in all the resources created on the cluster. This now makes it possible for someone to submit multiple submissions in parallel. Previously, the would have collided either on disk (local results_dir) or b/c the helm chart deployed a pytorchjob/configmap that had a static name (not dependent on the release name)
* This also introduces a `volumes` key in `k8s.yaml` to specify hostPath, NFS, or PVCs and is backward compatible with the previous support, which only allowed NFS.
* PEFT also did a local download of squad, which was disabled for the k8s launcher and it now only downloads in a pre-install hook. Since the download is fairly quick, it seemed acceptable and adds ~5min to the deployment if the data has never been downloaded to the volume before. If it has, it should finish very quickly < 1min.
* the `cluster` config is now resolved for k8s since the hydra variable references `$(...}` needed to be resolved before passing to helm
* the submission for k8s (`helm install`) now has the `--timeout` and `--wait` flag passed since the 5 minute default was too short