### PR TITLE
Disable the use of atomic-counter GEMM in tensor-parallel communication

### DIFF
--- a/launcher_scripts/conf/training/gpt3/126m.yaml
+++ b/launcher_scripts/conf/training/gpt3/126m.yaml
@@ -144,6 +144,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   # miscellaneous
   seed: 1234

--- a/launcher_scripts/conf/training/gpt3/175b.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b.yaml
@@ -147,6 +147,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   # miscellaneous
   seed: 1234

--- a/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
+++ b/launcher_scripts/conf/training/gpt3/175b_fp8.yaml
@@ -147,6 +147,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   # miscellaneous
   seed: 1234

--- a/launcher_scripts/conf/training/gpt3/1b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/1b_improved.yaml
@@ -150,6 +150,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   optim:
     name: distributed_fused_adam

--- a/launcher_scripts/conf/training/gpt3/20b.yaml
+++ b/launcher_scripts/conf/training/gpt3/20b.yaml
@@ -147,6 +147,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   # miscellaneous
   seed: 1234

--- a/launcher_scripts/conf/training/gpt3/400m_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/400m_improved.yaml
@@ -150,6 +150,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   optim:
     name: distributed_fused_adam

--- a/launcher_scripts/conf/training/gpt3/40b.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b.yaml
@@ -147,6 +147,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: True
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   # miscellaneous
   seed: 1234

--- a/launcher_scripts/conf/training/gpt3/40b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/40b_improved.yaml
@@ -150,6 +150,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   optim:
     name: distributed_fused_adam

--- a/launcher_scripts/conf/training/gpt3/5b.yaml
+++ b/launcher_scripts/conf/training/gpt3/5b.yaml
@@ -147,6 +147,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   # miscellaneous
   seed: 1234

--- a/launcher_scripts/conf/training/gpt3/7b_improved.yaml
+++ b/launcher_scripts/conf/training/gpt3/7b_improved.yaml
@@ -150,6 +150,8 @@ model:
   fp8_amax_compute_algo: max # 'most_recent' or 'max'. Algorithm for computing amax from history
   fp8_wgrad: True
   ub_tp_comm_overlap: False
+  tp_comm_atomic_ag: False
+  tp_comm_atomic_rs: False
 
   optim:
     name: distributed_fused_adam


### PR DESCRIPTION
Disable the use of atomic-counter GEMM in tensor-parallel communication.
The performance of atomic-GEMM is still under exploration.