### PR TITLE
Remove outdated fp8 comment

### DIFF
--- a/auto_configurator/base_configs/llama2_7b.yaml
+++ b/auto_configurator/base_configs/llama2_7b.yaml
@@ -118,7 +118,6 @@ model:
   sequence_parallel: false # does not support sequence parallel
 
   ## Transformer Engine
-  # fp8 training is currently not supported in the improved models
   transformer_engine: true
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3

--- a/launcher_scripts/conf/training/llama/llama1_7b.yaml
+++ b/launcher_scripts/conf/training/llama/llama1_7b.yaml
@@ -117,7 +117,6 @@ model:
   sequence_parallel: false # does not support sequence parallel
 
   ## Transformer Engine
-  # fp8 training is currently not supported in the improved models
   transformer_engine: True
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3

--- a/launcher_scripts/conf/training/llama/llama2_7b.yaml
+++ b/launcher_scripts/conf/training/llama/llama2_7b.yaml
@@ -125,7 +125,6 @@ model:
   sequence_parallel: false
 
   ## Transformer Engine
-  # fp8 training is currently not supported in the improved models
   transformer_engine: true
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3

--- a/launcher_scripts/conf/training/nemotron/nemotron_15b.yaml
+++ b/launcher_scripts/conf/training/nemotron/nemotron_15b.yaml
@@ -144,7 +144,6 @@ model:
   mcore_gpt: True
 
   ## Transformer Engine
-  # fp8 training is currently not supported in the improved models
   transformer_engine: True
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3

--- a/launcher_scripts/conf/training/nemotron/nemotron_22b.yaml
+++ b/launcher_scripts/conf/training/nemotron/nemotron_22b.yaml
@@ -144,7 +144,6 @@ model:
   mcore_gpt: True
 
   ## Transformer Engine
-  # fp8 training is currently not supported in the improved models
   transformer_engine: True
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3

--- a/launcher_scripts/conf/training/nemotron/nemotron_8b.yaml
+++ b/launcher_scripts/conf/training/nemotron/nemotron_8b.yaml
@@ -144,7 +144,6 @@ model:
   mcore_gpt: True
 
   ## Transformer Engine
-  # fp8 training is currently not supported in the improved models
   transformer_engine: True
   fp8: False # enables fp8 in TransformerLayer forward
   fp8_e4m3: False # sets fp8_format = recipe.Format.E4M3


### PR DESCRIPTION
Remove a confusing comment regarding FP8 support. The comment was copied from other configs and do not apply to llama and nemotron.
